### PR TITLE
Improvement/disable update

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ you used the example file, the password is `atropos`.
 | FOUNDRY_ROUTE_PREFIX | A string path which is appended to the base hostname to serve Foundry VTT content from a specific namespace. For example setting this to `demo` will result in data being served from `http://x.x.x.x:30000/demo/`. | null |
 | FOUNDRY_SSL_CERT | An absolute or relative path that points towards a SSL certificate file which is used jointly with the sslKey option to enable SSL and https connections. If both options are provided, the server will start using HTTPS automatically. | null |
 | FOUNDRY_SSL_KEY | An absolute or relative path that points towards a SSL key file which is used jointly with the sslCert option to enable SSL and https connections. If both options are provided, the server will start using HTTPS automatically. | null |
-| FOUNDRY_UPDATE_CHANNEL | The update channel to subscribe to.  "alpha", "beta", or "release". | "beta" |
+| FOUNDRY_UPDATE_CHANNEL | The update channel to subscribe to.  "alpha", "beta", or "release". | "release" |
 | FOUNDRY_UPNP | Allow Universal Plug and Play to automatically request port forwarding for the Foundry VTT port to your local network address. | false |
 | FOUNDRY_WORLD | The world startup at system start. | null |
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,27 @@ If all goes well you should be prompted for your "License Key", the license
 agreement, and then "admin access key" from the `docker-compose.yml` file.  If
 you used the example file, the password is `atropos`.
 
+## Updating ##
+
+The Foundry "Update Software" tab is disabled by default in this container. To
+upgrade to a new version of Foundry, update this repository to the latest
+version and rebuild the image.
+
+1. Stop the running container:
+
+    ```console
+    docker-compose down
+    ```
+
+1. Update to the latest release of this repository:
+
+    ```console
+    git pull
+    ```
+
+1. Follow the previous instructions for [building](#building) and
+   [running](#running) the container above.
+
 ## Volumes ##
 
 | Mount point | Purpose        |
@@ -79,6 +100,7 @@ you used the example file, the password is `atropos`.
 | FOUNDRY_ADMIN_KEY | Admin password.  |  |
 | FOUNDRY_AWS_CONFIG | An absolute or relative path that points to the [awsConfig.json](https://foundryvtt.com/article/aws-s3/) or `true` for AWS environment variable [credentials evaluation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) usage | null |
 | FOUNDRY_HOSTNAME | A custom hostname to use in place of the host machine's public IP address when displaying the address of the game session. This allows for reverse proxies or DNS servers to modify the public address. | null |
+| FOUNDRY_NO_UPDATE | Prevent the application from being updated from the web interface.  The application code is immutable when running in a container.  See the [Updating](#updating) section for the steps needed to update this container. | true |
 | FOUNDRY_PROXY_PORT | Inform the Foundry Server that the software is running behind a reverse proxy on some other port. This allows the invitation links created to the game to include the correct external port. | null |
 | FOUNDRY_PROXY_SSL | Indicates whether the software is running behind a reverse proxy that uses SSL. This allows invitation links and A/V functionality to work as if the Foundry Server had SSL configured directly. | false |
 | FOUNDRY_ROUTE_PREFIX | A string path which is appended to the base hostname to serve Foundry VTT content from a specific namespace. For example setting this to `demo` will result in data being served from `http://x.x.x.x:30000/demo/`. | null |

--- a/docker-compose-pytest.yml
+++ b/docker-compose-pytest.yml
@@ -22,6 +22,7 @@ services:
       - FOUNDRY_AWS_CONFIG=
       - FOUNDRY_GID=foundry
       - FOUNDRY_HOSTNAME=
+      - FOUNDRY_NO_UPDATE=true
       - FOUNDRY_PROXY_PORT=
       - FOUNDRY_PROXY_SSL=false
       - FOUNDRY_ROUTE_PREFIX=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - FOUNDRY_AWS_CONFIG=
       - FOUNDRY_GID=foundry
       - FOUNDRY_HOSTNAME=
+      - FOUNDRY_NO_UPDATE=true
       - FOUNDRY_PROXY_PORT=
       - FOUNDRY_PROXY_SSL=false
       - FOUNDRY_ROUTE_PREFIX=

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -69,7 +69,7 @@ cat <<EOF > /data/Config/options.json
   "routePrefix": ${FOUNDRY_ROUTE_PREFIX:-null},
   "sslCert": ${FOUNDRY_SSL_CERT:-null},
   "sslKey": ${FOUNDRY_SSL_KEY:-null},
-  "updateChannel": ${FOUNDRY_UPDATE_CHANNEL:-\"beta\"},
+  "updateChannel": ${FOUNDRY_UPDATE_CHANNEL:-\"release\"},
   "upnp": ${FOUNDRY_UPNP:-false},
   "world": ${FOUNDRY_WORLD:-null}
 }

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -59,18 +59,18 @@ set -o nounset
 mkdir -p /data/Config >& /dev/null
 cat <<EOF > /data/Config/options.json
 {
-  "port": 30000,
-  "upnp": ${FOUNDRY_UPNP:-false},
+  "awsConfig": ${FOUNDRY_AWS_CONFIG:-null},
+  "dataPath": "/data",
   "fullscreen": false,
   "hostname": ${FOUNDRY_HOSTNAME:-null},
+  "port": 30000,
+  "proxyPort": ${FOUNDRY_PROXY_PORT:-null},
+  "proxySSL": ${FOUNDRY_PROXY_SSL:-false},
   "routePrefix": ${FOUNDRY_ROUTE_PREFIX:-null},
   "sslCert": ${FOUNDRY_SSL_CERT:-null},
   "sslKey": ${FOUNDRY_SSL_KEY:-null},
-  "awsConfig": ${FOUNDRY_AWS_CONFIG:-null},
-  "dataPath": "/data",
-  "proxySSL": ${FOUNDRY_PROXY_SSL:-false},
-  "proxyPort": ${FOUNDRY_PROXY_PORT:-null},
   "updateChannel": ${FOUNDRY_UPDATE_CHANNEL:-\"beta\"},
+  "upnp": ${FOUNDRY_UPNP:-false},
   "world": ${FOUNDRY_WORLD:-null}
 }
 EOF

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -63,6 +63,7 @@ cat <<EOF > /data/Config/options.json
   "dataPath": "/data",
   "fullscreen": false,
   "hostname": ${FOUNDRY_HOSTNAME:-null},
+  "noUpdate": ${FOUNDRY_NO_UPDATE:-true},
   "port": 30000,
   "proxyPort": ${FOUNDRY_PROXY_PORT:-null},
   "proxySSL": ${FOUNDRY_PROXY_SSL:-false},


### PR DESCRIPTION
Updates via the GUI / web interface will likely fail with a permission error.  Any update that was successfully applied would be reverted as soon as the container was restarted.  To prevent this World of Hurt™ for users we'll disable that update mechanism, and provide instructions for the Docker-way™ of doing updates.