### PR TITLE
Improve flexibility of FOUNDRY_USERNAME contents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/felddy/foundryvtt)](https://hub.docker.com/r/felddy/foundryvtt)
 [![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/felddy/foundryvtt)](https://hub.docker.com/r/felddy/foundryvtt)
-![Platforms](https://img.shields.io/badge/platforms-386%20%7C%20amd64%20%7C%20arm%2Fv6%20%7C%20arm%2Fv7%20%7C%20arm64%20%7C%20ppc64le%20%7C%20s390x-blue)
+[![Platforms](https://img.shields.io/badge/platforms-386%20%7C%20amd64%20%7C%20arm%2Fv6%20%7C%20arm%2Fv7%20%7C%20arm64%20%7C%20ppc64le%20%7C%20s390x-blue)](https://hub.docker.com/r/felddy/foundryvtt/tags)
 
 You can get a [Foundry Virtual Tabletop](https://foundryvtt.com) instance up and
 running in minutes using this container.  This Docker container is designed to

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ upgrade to a new version of Foundry, update your image to the latest version.
 
 | Name             | Purpose  |
 |------------------|----------|
-| FOUNDRY_USERNAME | Account username for foundryvtt.com.  Required for downloading an application release. |
+| FOUNDRY_USERNAME | Account username or email address for foundryvtt.com.  Required for downloading an application release. |
 | FOUNDRY_PASSWORD | Account password for foundryvtt.com.  Required for downloading an application release. |
 
 ### Optional ###

--- a/src/download_release.js
+++ b/src/download_release.js
@@ -20,7 +20,7 @@ Options:
 // Argument parsing
 const { docopt } = require("docopt");
 const options = docopt(doc, { version: "0.0.1" });
-const username = options["<username>"];
+const username = options["<username>"].toLowerCase();
 const password = options["<password>"];
 const foundry_version = options["<version>"];
 

--- a/src/download_release.js
+++ b/src/download_release.js
@@ -2,7 +2,11 @@
 /* eslint-disable no-console */
 
 const doc = `
-Download the foundry release using valid credentials.
+Download a Foundry Virtual Tabletop release and license key using valid credentials.
+This utility will attempt to create two files:
+
+    foundryvtt-x.y.z.zip - An archive containing the release.
+    license.json - A json file containing the license key.
 
 EXIT STATUS
     This utility exits with one of the following values:

--- a/src/download_release.js
+++ b/src/download_release.js
@@ -148,4 +148,6 @@ const HEADERS = {
     throw new Error(`Unexpected response ${response.statusText}`);
   }
   streamPipeline(response.body, fs.createWriteStream(RELEASE_PATH));
+
+  return 0;
 })();


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
Fixes #16

The `FOUNDRY_USERNAME` environment variable was assumed to have a username in it.  Login can also succeed with an email address.  But this will then cause failures with the license fetch as the email address is improperly inserted into the license URL.  

If the `FOUNDRY_USERNAME` value is mixed case, the login will succeed but the license URL creation will fail similarly.   The username needs to be lower-cased in the URL.  

<!--- Describe your changes in detail -->

## 💭 Motivation and Context

Make life easier for our users.  It is not invalid for a user to provide an email address or have mixed case in their username.  

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

Tested with email addresses and usernames of various capitalization.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
