### PR TITLE
Bug fix for site capitalization and license URL construction

### DIFF
--- a/src/_version.py
+++ b/src/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.1+d"

--- a/src/_version.py
+++ b/src/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "0.6.1+d"
+__version__ = "0.6.1"

--- a/src/download_release.js
+++ b/src/download_release.js
@@ -60,6 +60,7 @@ const HEADERS = {
 async function fetchTokens() {
   // Make a request to the main site to get our two CSRF tokens
   logger.info(`Requesting CSRF tokens from ${BASE_URL}`);
+  logger.debug(`Fetching: ${BASE_URL}`);
   const response = await fetch(BASE_URL, {
     method: "GET",
     headers: HEADERS,
@@ -96,6 +97,7 @@ async function login(csrfmiddlewaretoken, username, password) {
   });
 
   logger.info(`Logging in as: ${username}`);
+  logger.debug(`Fetching: ${LOGIN_URL}`);
   const response = await fetch(LOGIN_URL, {
     body: form_params,
     method: "POST",
@@ -136,6 +138,7 @@ async function login(csrfmiddlewaretoken, username, password) {
 async function fetchLicense(username) {
   logger.info("Fetching license.");
   const LICENSE_URL = `${BASE_URL}/community/${username}/licenses`;
+  logger.debug(`Fetching: ${LICENSE_URL}`);
   const response = await fetch(LICENSE_URL, {
     method: "GET",
     headers: HEADERS,
@@ -184,6 +187,7 @@ async function saveLicense(license, filename) {
 async function downloadRelease(version, path) {
   logger.info(`Downloading release ${version} to ${path}...`);
   const release_url = `${BASE_URL}/releases/download?version=${version}&platform=linux`;
+  logger.debug(`Fetching: ${release_url}`);
   const response = await fetch(release_url, {
     method: "GET",
     headers: HEADERS,

--- a/src/download_release.js
+++ b/src/download_release.js
@@ -122,7 +122,9 @@ async function login(csrfmiddlewaretoken, username, password) {
   // A user may login with an e-mail address.  Resolve it to a username now.
   const loggedInUsername = $("#login-welcome a").attr("title");
   logger.info(`Successfully logged in as: ${loggedInUsername}`);
-  return loggedInUsername;
+
+  // The site preserves case, but this will break our use in the LICENSE_URL
+  return loggedInUsername.toLowerCase();
 }
 
 /**


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

Fixes #19 

If `FOUNDRY_USERNAME` is set to `foobar` it is possible for FoundryVTT can respond with:
`Successfully logged in as: Foobar` (note the case change)

We use the reply username since some users set `FOUNDRY_USERNAME` to their email address.

When the `LICENSE_URL` is constructed, it is invalid with the capitalized username.  

The solution is to lowercase the returned username before it is used in the URL.


## 💭 Motivation and Context

Breaking for some users.

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Normal test suite.  I don't have an account with caps, so I cannot test live.  Will rely on @shirkie 

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
