### PR TITLE
Improvement:  S3 Pre-signed URLs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 Dockerfile-x
 license.json
 node_modules
+package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG FOUNDRY_PASSWORD
+ARG FOUNDRY_RELEASE_URL
 ARG FOUNDRY_USERNAME
 ARG FOUNDRY_VERSION=0.6.2
 ARG GIT_COMMIT=unspecified
@@ -8,6 +9,7 @@ ARG VERSION
 FROM node:12-alpine as optional-release-stage
 
 ARG FOUNDRY_PASSWORD
+ARG FOUNDRY_RELEASE_URL
 ARG FOUNDRY_USERNAME
 ARG FOUNDRY_VERSION
 ENV ARCHIVE="foundryvtt-${FOUNDRY_VERSION}.zip"
@@ -18,7 +20,11 @@ COPY src/package.json src/authenticate.js ./
 RUN mkdir dist && touch dist/.placeholder
 RUN if [ -n "${FOUNDRY_USERNAME}" ] && [ -n "${FOUNDRY_PASSWORD}" ]; then \
       npm install && \
-      ./authenticate.js "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}" && \
+      s3_url=$(./authenticate.js "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}") && \
+      wget -O ${ARCHIVE} "${s3_url}" && \
+      unzip -d dist ${ARCHIVE} 'resources/*'; \
+    elif [ -n "${FOUNDRY_RELEASE_URL}" ]; then \
+      wget -O ${ARCHIVE} "${FOUNDRY_RELEASE_URL}" && \
       unzip -d dist ${ARCHIVE} 'resources/*'; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,12 @@ ARG FOUNDRY_VERSION
 ENV ARCHIVE="foundryvtt-${FOUNDRY_VERSION}.zip"
 
 WORKDIR /root
-COPY src/package.json src/download_release.js ./
+COPY src/package.json src/authenticate.js ./
 # .placeholder file to mitigate https://github.com/moby/moby/issues/37965
 RUN mkdir dist && touch dist/.placeholder
 RUN if [ -n "${FOUNDRY_USERNAME}" ] && [ -n "${FOUNDRY_PASSWORD}" ]; then \
       npm install && \
-      ./download_release.js "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}" && \
+      ./authenticate.js "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}" && \
       unzip -d dist ${ARCHIVE} 'resources/*'; \
     fi
 
@@ -51,7 +51,7 @@ RUN apk --update --no-cache add jq su-exec
 WORKDIR ${FOUNDRY_HOME}
 
 COPY --from=optional-release-stage /root/dist/ .
-COPY src/entrypoint.sh src/package.json src/set_password.js src/download_release.js ./
+COPY src/entrypoint.sh src/package.json src/set_password.js src/authenticate.js ./
 RUN npm install && echo ${VERSION} > image_version.txt
 
 VOLUME ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY src/package.json src/download_release.js ./
 RUN mkdir dist && touch dist/.placeholder
 RUN if [ -n "${FOUNDRY_USERNAME}" ] && [ -n "${FOUNDRY_PASSWORD}" ]; then \
       npm install && \
-      ./download_release.js --no-license "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}" && \
+      ./download_release.js "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}" && \
       unzip -d dist ${ARCHIVE} 'resources/*'; \
     fi
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ provide the credentials needed to download a Foundry Virtual Tabletop release.
 
 ## Running ##
 
-### Using Docker ###
+### Using Docker with credentials ###
 
 You can use the following command to start up a Foundry Virtual Tabletop server.
 Your [foundryvtt.com](https://foundryvtt.com) credentials are required so the
@@ -39,7 +39,22 @@ docker run \
   felddy/foundryvtt:latest
 ```
 
-### Using a Docker composition ###
+### Using Docker with a temporary URL ###
+
+Alternatively, you may acquire a temporary download token from your user profile
+page on the Foundry website.  On the "Purchased Licenses" page, click the [🔗]
+icon to the right of the standard `Node.js` download link to obtain a temporary
+download URL for the software.
+
+```console
+ docker run \
+  --env FOUNDRY_RELEASE_URL='<temporary_url>' \
+  --publish 30000:30000/tcp \
+  --volume /data:<your_data_dir> \
+  felddy/foundryvtt:latest
+```
+
+## Using a Docker composition ###
 
 Using [`docker-compose`](https://docs.docker.com/compose/install/) to manage your
 server is highly recommended.  A `docker-compose.yml` file is a more reliable
@@ -135,10 +150,14 @@ upgrade to a new version of Foundry, update your image to the latest version.
 
 ### Required ###
 
+Either (`FOUNDRY_USERNAME` and `FOUNDRY_PASSWORD`) or `FOUNDRY_RELEASE_URL` must
+be provided.
+
 | Name             | Purpose  |
 |------------------|----------|
 | FOUNDRY_USERNAME | Account username or email address for foundryvtt.com.  Required for downloading an application release. |
 | FOUNDRY_PASSWORD | Account password for foundryvtt.com.  Required for downloading an application release. |
+| FOUNDRY_RELEASE_URL | S3 pre-signed URL generate from the user's profile.  Required for downloading an application release. |
 
 ### Optional ###
 
@@ -220,6 +239,15 @@ stored in the resulting image.
     docker build \
       --build-arg FOUNDRY_USERNAME='<your_username>' \
       --build-arg FOUNDRY_PASSWORD='<your_password>' \
+      --build-arg VERSION=0.6.2 \
+      --tag felddy/foundryvtt:0.6.2 .
+    ```
+
+1. Or build the image with a temporary URL:
+
+    ```console
+    docker build \
+      --build-arg FOUNDRY_RELEASE_URL='<temporary_url>' \
       --build-arg VERSION=0.6.2 \
       --tag felddy/foundryvtt:0.6.2 .
     ```

--- a/README.md
+++ b/README.md
@@ -233,24 +233,24 @@ faster startup.  It also moves the user authentication to build-time instead of
 start-time.  **Note**: Credentials are only used to fetch a release, and are not
 stored in the resulting image.
 
-1. Build the image with credentials:
+Build the image with credentials:
 
-    ```console
-    docker build \
-      --build-arg FOUNDRY_USERNAME='<your_username>' \
-      --build-arg FOUNDRY_PASSWORD='<your_password>' \
-      --build-arg VERSION=0.6.2 \
-      --tag felddy/foundryvtt:0.6.2 .
-    ```
+```console
+docker build \
+  --build-arg FOUNDRY_USERNAME='<your_username>' \
+  --build-arg FOUNDRY_PASSWORD='<your_password>' \
+  --build-arg VERSION=0.6.2 \
+  --tag felddy/foundryvtt:0.6.2 .
+```
 
-1. Or build the image with a temporary URL:
+Or build the image using a temporary URL:
 
-    ```console
-    docker build \
-      --build-arg FOUNDRY_RELEASE_URL='<temporary_url>' \
-      --build-arg VERSION=0.6.2 \
-      --tag felddy/foundryvtt:0.6.2 .
-    ```
+```console
+docker build \
+  --build-arg FOUNDRY_RELEASE_URL='<temporary_url>' \
+  --build-arg VERSION=0.6.2 \
+  --tag felddy/foundryvtt:0.6.2 .
+```
 
 ## Hosting behind Nginx with TLS ##
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ docker run \
   felddy/foundryvtt:latest
 ```
 
+If you are using `bash`, or a similar shell, consider pre-pending the Docker
+command with a space to prevent your credentials from being committed to the
+shell history list.  See:
+[`HISTCONTROL`](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-HISTCONTROL)
+
 ### Using Docker with a temporary URL ###
 
 Alternatively, you may acquire a temporary download token from your user profile

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ icon to the right of the standard `Node.js` download link to obtain a temporary
 download URL for the software.
 
 ```console
- docker run \
+docker run \
   --env FOUNDRY_RELEASE_URL='<temporary_url>' \
   --publish 30000:30000/tcp \
   --volume /data:<your_data_dir> \

--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -239,7 +239,7 @@ async function main() {
 
   if (license_filename) {
     // Attempt to fetch a license key.
-    const license = await fetchLicense(loggedInUsername);
+    const license_key = await fetchLicense(loggedInUsername);
     if (license_key) {
       await saveLicense(license_key, license_filename);
     } else {

--- a/src/authenticate.js
+++ b/src/authenticate.js
@@ -12,8 +12,8 @@ EXIT STATUS
     >0  An error occurred.
 
 Usage:
-  download_release.js [--log-level=LEVEL] [--license=filename] <username> <password> <version>
-  download_release.js (-h | --help)
+  authenticate.js [--log-level=LEVEL] [--license=filename] <username> <password> <version>
+  authenticate.js (-h | --help)
 
 Options:
   -h --help              Show this message.

--- a/src/download_release.js
+++ b/src/download_release.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
 const doc = `
-Download a Foundry Virtual Tabletop release and license key using valid credentials.
-This utility will attempt to create two files:
+Generate a Foundry Virtual Tabletop pre-signed release URL and optionally fetch
+license key using valid credentials.
 
-    foundryvtt-x.y.z.zip - An archive containing the release.
-    license.json - A json file containing the license key.
+The utility will print the release URL to standard out.
 
 EXIT STATUS
     This utility exits with one of the following values:
@@ -13,7 +12,7 @@ EXIT STATUS
     >0  An error occurred.
 
 Usage:
-  download_release.js [--log-level=LEVEL] [--no-license] <username> <password> <version>
+  download_release.js [--log-level=LEVEL] [--license=filename] <username> <password> <version>
   download_release.js (-h | --help)
 
 Options:
@@ -21,7 +20,7 @@ Options:
   --log-level=LEVEL      If specified, then the log level will be set to
                          the specified value.  Valid values are "trace", "debug", "info",
                          "warn", "error", and "fatal". [default: info]
-  --no-license           Do not create a license key file.
+  --license=filename     Fetch a license key and save it to a JSON file.
 `;
 
 // Argument parsing
@@ -218,7 +217,7 @@ async function main() {
   const password = options["<password>"];
   const foundry_version = options["<version>"];
   const log_level = options["--log-level"].toLowerCase();
-  const no_license = options["--no-license"];
+  const license_filename = options["--license"];
 
   // Setup logging.
   logger = pino(
@@ -238,16 +237,14 @@ async function main() {
   // Login using the credentials, tokens, and cookies.
   const loggedInUsername = await login(csrfmiddlewaretoken, username, password);
 
-  if (!no_license) {
+  if (license_filename) {
     // Attempt to fetch a license key.
     const license = await fetchLicense(loggedInUsername);
-    if (license) {
-      await saveLicense(license, "license.json");
+    if (license_key) {
+      await saveLicense(license_key, license_filename);
     } else {
-      logger.warn("Could not find license.");
+      logger.warn("Could not find license key.");
     }
-  } else {
-    logger.debug("Not fetching license, --no-license flag set.");
   }
 
   // Generate an S3 pre-signed URL and print it to stdout.

--- a/src/download_release.js
+++ b/src/download_release.js
@@ -37,6 +37,7 @@ const cookieJar = new _tough.CookieJar();
 const fetch = require("fetch-cookie/node-fetch")(_nodeFetch, cookieJar);
 const fs = require("fs");
 const pino = require("pino");
+const process = require("process");
 const streamPipeline = _util.promisify(require("stream").pipeline);
 
 // Setup logger global, configure in main()
@@ -218,13 +219,16 @@ async function main() {
   const no_license = options["--no-license"];
 
   // Setup logging.
-  logger = pino({
-    level: log_level,
-    prettyPrint: {
-      translateTime: true,
-      ignore: "pid,hostname",
+  logger = pino(
+    {
+      level: log_level,
+      prettyPrint: {
+        translateTime: true,
+        ignore: "pid,hostname",
+      },
     },
-  });
+    pino.destination(process.stderr.fd)
+  );
 
   // Get the tokens and cookies we'll need to login.
   const csrfmiddlewaretoken = await fetchTokens();

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -41,9 +41,9 @@ if [ $install_required = true ]; then
   fi
   echo "Installing Foundry Virtual Tabletop ${FOUNDRY_VERSION}"
   if [[ ${CONTAINER_VERBOSE} ]]; then
-    ./download_release.js --log-level=trace --license=license.json "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}"
+    ./authenticate.js --log-level=trace --license=license.json "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}"
   else
-    ./download_release.js --license=license.json "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}"
+    ./authenticate.js --license=license.json "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}"
   fi
   set -o nounset
   unzip -q "foundryvtt-${FOUNDRY_VERSION}.zip" 'resources/*'

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -135,6 +135,6 @@ else
 fi
 set -o nounset
 
+# Spawn node with clean environment to prevent credential leaks
 echo "Starting Foundry Virtual Tabletop."
-
-node "$@"
+env -i node "$@"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -41,9 +41,9 @@ if [ $install_required = true ]; then
   fi
   echo "Installing Foundry Virtual Tabletop ${FOUNDRY_VERSION}"
   if [[ ${CONTAINER_VERBOSE} ]]; then
-    ./download_release.js --log-level=trace "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}"
+    ./download_release.js --log-level=trace --license=license.json "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}"
   else
-    ./download_release.js "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}"
+    ./download_release.js --license=license.json "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}"
   fi
   set -o nounset
   unzip -q "foundryvtt-${FOUNDRY_VERSION}.zip" 'resources/*'

--- a/src/package.json
+++ b/src/package.json
@@ -19,7 +19,7 @@
     "docker"
   ],
   "license": "CC0-1.0",
-  "main": "download_release.js",
+  "main": "authenticate.js",
   "name": "foundryvtt-utils",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

Addresses issue #25 

Allow users to provide a pre-signed S3 URL (via `FOUNDRY_RELEASE_URL`)  as the mechanism to download the foundry release in both startup and "pre-bake" builds.  These URLs may be generated from the user's profile page by clicking on the 🔗 icon next to the distribution.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context

Users may be wary or providing credentials to a container. Not all users have the ability to do a code review of project and trust the code is not harvesting their credentials.

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
