### PR TITLE
Improvement/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,42 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve
+---
+
+# 🐛 Bug Report
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+- Do this
+- Then this
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Any helpful log output
+
+Please run this command:
+
+```bash
+docker inspect --format='{{range $k, $v := .Config.Labels}}
+    {{- printf "%s = \"%s\"\n" $k $v -}} {{end}}' \
+    felddy/foundryvtt:latest
+```
+
+Paste the results here:
+
+```console
+
+```
+
+Run the container with `CONTAINER_VERBOSE` set to `true`,and paste any useful
+log output here:
+
+```console
+
+```

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,20 @@
+---
+name: 🚀 Feature Proposal
+about: Submit a proposal for a new feature
+---
+
+# 🚀 Feature Proposal
+
+A clear and concise description of what the feature is.
+
+## Motivation
+
+Please outline the motivation for the proposal.
+
+## Example
+
+Please provide an example for how this feature would be used.
+
+## Pitch
+
+Why does this feature belong in this project?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,6 @@
+---
+name: 💬 Questions / Help
+about: Ask a question or get some help
+---
+
+# 💬 Questions and Help

--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -1,0 +1,48 @@
+---
+name: 💥 Regression Report
+about: Report unexpected behavior that worked in previous versions
+---
+
+# 💥 Regression Report
+
+A clear and concise description of what the regression is.
+
+## Last working version
+
+Worked up to version:
+
+Stopped working in version:
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+- Do this
+- Then this
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Any helpful log output
+
+Please run this command:
+
+```bash
+docker inspect --format='{{range $k, $v := .Config.Labels}}
+    {{- printf "%s = \"%s\"\n" $k $v -}} {{end}}' \
+    felddy/foundryvtt:latest
+```
+
+Paste the results here:
+
+```console
+
+```
+
+Run the container with `CONTAINER_VERBOSE` set to `true`,and paste any useful
+log output here:
+
+```console
+
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
             --tag "${IMAGE_NAME}:${{ steps.get_ver.outputs.version }}" \
             --tag "${IMAGE_NAME}:${v_major}.${v_minor}" \
             --tag "${IMAGE_NAME}:${v_major}" \
+            --build-arg CREATED_TIMESTAMP=$(date --rfc-3339=seconds) \
             --build-arg GIT_COMMIT=$(git log -1 --format=%H) \
             --build-arg GIT_REMOTE=$(git remote get-url origin) \
             --build-arg VERSION=${{ steps.get_ver.outputs.version }} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG CREATED_TIMESTAMP=unspecified
 ARG FOUNDRY_PASSWORD
 ARG FOUNDRY_RELEASE_URL
 ARG FOUNDRY_USERNAME
@@ -30,6 +31,7 @@ RUN if [ -n "${FOUNDRY_USERNAME}" ] && [ -n "${FOUNDRY_PASSWORD}" ]; then \
 
 FROM node:12-alpine as final-stage
 
+ARG CREATED_TIMESTAMP=unspecified
 ARG FOUNDRY_UID=421
 ARG FOUNDRY_VERSION
 ARG GIT_COMMIT
@@ -39,6 +41,7 @@ ARG VERSION
 
 LABEL com.foundryvtt.version=${FOUNDRY_VERSION}
 LABEL org.opencontainers.image.authors="markf+github@geekpad.com"
+LABEL org.opencontainers.image.created=${CREATED_TIMESTAMP}
 LABEL org.opencontainers.image.licenses="CC0-1.0"
 LABEL org.opencontainers.image.revision=${GIT_COMMIT}
 LABEL org.opencontainers.image.source=${GIT_REMOTE}


### PR DESCRIPTION
Issue templates are failing in default community files for non-orgs: 
https://github.community/t/default-community-files-ignores-issue-templates/2802

Moving them into the repo as a work around. 
