### PR TITLE
Allow HOME environment variable to pass to Node.

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -165,4 +165,4 @@ set -o nounset
 
 # Spawn node with clean environment to prevent credential leaks
 echo "Starting Foundry Virtual Tabletop."
-env -i node "$@"
+env -i HOME="$HOME" node "$@"


### PR DESCRIPTION


# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

See issue #38 

Setting uid:gid to some values was causing a startup failure inside Foundry main when it tried to call `os.homedir()`

```console
foundry    | SystemError [ERR_SYSTEM_ERROR]: A system error occurred: uv_os_homedir returned ENOENT (no such file or directory)
foundry    |     at _getEnvDataPath (/home/foundry/resources/app/main.js:128:22)
foundry    |     at getPaths (/home/foundry/resources/app/main.js:55:23)
foundry    |     at Object.<anonymous> (/home/foundry/resources/app/main.js:158:18)
foundry    |     at Module._compile (internal/modules/cjs/loader.js:1138:30)
foundry    |     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
foundry    |     at Module.load (internal/modules/cjs/loader.js:986:32)
foundry    |     at Function.Module._load (internal/modules/cjs/loader.js:879:14)
foundry    |     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
foundry    |     at internal/main/run_main_module.js:17:47
```

Allowing the `HOME` environment variable to be passed into Node's environment fixes this issue.   Previously Node was
being launched in an empty environment to prevent credential or other sensitive information leaks. 

## 💭 Motivation and Context

See issue: #38

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I was able to reproduce the error using uid:gid `111:115` but not with `100:1000` which is what I normally use on my server.  When passing in `HOME` to Node the error is not thrown. 

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
