### PR TITLE
Add support for container patching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ secrets](#using-secrets) instead of environment variables.
 
 | Name  | Purpose | Default |
 |-------|---------|---------|
-| CONTAINER_CACHE   | Set a path to cache downloads of the Foundry release archive and speed up subsequent container startups.  The path should be in `/data` or another persistent mount point in the container. e.g.; `/data/container_cache`| |
+| CONTAINER_CACHE | Set a path to cache downloads of the Foundry release archive and speed up subsequent container startups.  The path should be in `/data` or another persistent mount point in the container. e.g.; `/data/container_cache`| |
+| CONTAINER_PATCHES | Set a path to a directory of shell scripts to be sourced after Foundry is installed but before it is started.  The path should be in `/data` or another persistent mount point in the container. e.g.; `/data/container_patches`| |
 | CONTAINER_VERBOSE | Set to `true` to enable verbose logging for the container utility scripts. | |
 | FOUNDRY_ADMIN_KEY | Admin password to be applied at startup.  If omitted the admin password will be cleared. | |
 | FOUNDRY_AWS_CONFIG | An absolute or relative path that points to the [awsConfig.json](https://foundryvtt.com/article/aws-s3/) or `true` for AWS environment variable [credentials evaluation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) usage. | null |

--- a/patches/hotfix_2020062801-0.6.4.sh
+++ b/patches/hotfix_2020062801-0.6.4.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Experimental Hotfix
+# =====================
+# This file corrects for the two most significant issues users are having with the 0.6.4 update.
+#
+# Hyperlink Embedding - corrects a problem with hyperlink embedding in rich text editors.
+# Wall Chaining - corrects the behavior of wall chaining which causes walls to sometimes chain from the wrong place.
+
+PATCH_DEST="$FOUNDRY_HOME/resources/app/public/scripts/foundry.js"
+PATCH_DOC_URL="https://discordapp.com/channels/170995199584108546/725021759144984646/726858730658070568"
+PATCH_NAME="Experimental Hotfix 2020062801 for 0.6.4"
+PATCH_URL="https://cdn.discordapp.com/attachments/725021759144984646/726858729957359668/foundry.js"
+TARGET_FOUNDRY_VERSION="0.6.4"
+
+if [ "$FOUNDRY_VERSION" = "$TARGET_FOUNDRY_VERSION" ]; then
+  echo "Applying \"${PATCH_NAME}\""
+  echo "See: ${PATCH_DOC_URL}"
+  curl --output "${PATCH_DEST}" "${PATCH_URL}" 2>&1 | tr "\r" "\n"
+else
+  echo "Not applying \"${PATCH_NAME}\".  This patch is targeted for Foundry Virtual Tabletop ${TARGET_FOUNDRY_VERSION}"
+fi

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -104,12 +104,15 @@ if [ $install_required = true ]; then
   fi
 fi
 
-# ensure the permissions are set correctly
-chown -R "${FOUNDRY_UID:-foundry}:${FOUNDRY_GID:-foundry}" /data
 
 if [ "$(id -u)" = 0 ]; then
   # set timezone using environment
   ln -snf /usr/share/zoneinfo/"${TIMEZONE:-UTC}" /etc/localtime
+
+  # ensure the permissions are set correctly
+  echo "Setting data directory permissions."
+  chown -R "${FOUNDRY_UID:-foundry}:${FOUNDRY_GID:-foundry}" /data
+
   if [ "${FOUNDRY_UID:-foundry}" != 0 ]; then
     # drop privileges and restart this script as foundry user
     echo "Switching uid:gid to ${FOUNDRY_UID:-foundry}:${FOUNDRY_GID:-foundry} and restarting."

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -102,8 +102,25 @@ if [ $install_required = true ]; then
     mkdir -p /data/Config
     mv license.json /data/Config
   fi
-fi
 
+  # apply patches if requested and the directory exists
+  if [[ ${CONTAINER_PATCHES} ]]; then
+    echo "Using CONTAINER_PATCHES: ${CONTAINER_PATCHES}"
+    if [ -d "${CONTAINER_PATCHES}" ]; then
+      echo "Container patches directory detected.  Starting patching..."
+      for f in "${CONTAINER_PATCHES}"/*
+      do
+        [ -f "$f" ] || continue # we can't set nullglob in busybox
+        echo "Sourcing patch from file: $f"
+        # shellcheck disable=SC1090
+        source "$f"
+      done
+      echo "Completed patching."
+    else
+      echo "Container patches directory not found."
+    fi
+  fi
+fi
 
 if [ "$(id -u)" = 0 ]; then
   # set timezone using environment


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->
Provides a mechanism to patch the container before the server starts.  

A patch directory can now be specified using the `CONTAINER_PATCHES` environment variable. 

## 💭 Motivation and Context

An experimental hot fix was released yesterday on Discord:
https://discordapp.com/channels/170995199584108546/725021759144984646/726858730658070568

A patch for this hot fix is included in the [`patches`](https://github.com/felddy/foundryvtt-docker/tree/develop/patches) directory of the repository.   The hot fix has already been
rolled into the `0.6.4` distribution on the `release` channel, so this patch is now a noop, but still useful to see how to
write a patch in the future.

Users were requesting a way to apply this hot fix.  This is the way.

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally, CI, and in production.

## 📷 Screenshots (if appropriate)
![s-l400](https://user-images.githubusercontent.com/3229435/86049283-e19aea00-ba1f-11ea-884a-5b889218d32a.jpg)
## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
