### PR TITLE
Bugfix: Unset CONTAINER_PATCHES causing startup failure.  Not detected in automated tests.

### DIFF
--- a/docker-compose-pytest.yml
+++ b/docker-compose-pytest.yml
@@ -8,12 +8,13 @@ services:
     image: felddy/foundryvtt:0.6.4
     hostname: felddy_foundryvtt
     init: true
-    restart: "unless-stopped"
+    restart: "no"
     volumes:
       - type: bind
         source: ./data
         target: /data
     environment:
+      - CONTAINER_VERBOSE=true
       - FOUNDRY_PASSWORD # pass through
       - FOUNDRY_USERNAME # pass through
       - TIMEZONE=US/Eastern

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -95,7 +95,6 @@ if [ $install_required = true ]; then
   else
     rm "${release_filename}"
   fi
-  set -o nounset
 
   if [ -f license.json ] && [ ! -f /data/Config/license.json ]; then
     echo "Applying license key."
@@ -120,6 +119,7 @@ if [ $install_required = true ]; then
       echo "Container patches directory not found."
     fi
   fi
+  set -o nounset
 fi
 
 if [ "$(id -u)" = 0 ]; then

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -8,7 +8,7 @@ import time
 # Third-Party Libraries
 import pytest
 
-READY_MESSAGE = "Foundry Virtual Tabletop"
+READY_MESSAGE = "Server started and listening on port"
 RELEASE_TAG = os.getenv("RELEASE_TAG")
 VERSION_FILE = "src/_version.py"
 


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->
Fix container tests that were passing when they should have failed.
Fix `nounset` being in the wrong part of the entrypoint script.  This was causing the check of `CONTAINER_PATCHES` to fail when unset.

Fixes #44 

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reported by @TimPansino in issue #44 

This was broken in the last release.
The tests were broken much earlier. 

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Fixed tests.  Ran locally in verbose mode. 

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
