### PR TITLE
Added option to provide a license key instead of retrieving

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - FOUNDRY_PASSWORD=<your_password>
       - FOUNDRY_USERNAME=<your_username>
       - FOUNDRY_ADMIN_KEY=atropos
+      # - FOUNDRY_LICENSE_KEY=<your_license_key>
       # - FOUNDRY_RELEASE_URL=<temporary_url>
       # - FOUNDRY_AWS_CONFIG=
       # - FOUNDRY_GID=foundry
@@ -30,6 +31,7 @@ services:
       # - FOUNDRY_VERSION=0.7.0
       # - FOUNDRY_WORLD=
       # - TIMEZONE=US/Eastern
+      # - CONTAINER_VERBOSE=true
     ports:
       - target: "30000"
         published: "30000"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -24,10 +24,13 @@ if [ -f "${secret_file}" ]; then
   secret_username=$(jq --exit-status --raw-output .foundry_username ${secret_file}) || secret_username=""
   secret_password=$(jq --exit-status --raw-output .foundry_password ${secret_file}) || secret_password=""
   secret_admin_key=$(jq --exit-status --raw-output .foundry_admin_key ${secret_file}) || secret_admin_key=""
+  secret_license_key$(jq --exit-status --raw-output .foundry_license_key ${secret_file}) || secret_license_key=""
+  
   # Override environment variables if secrets were set
   FOUNDRY_USERNAME=${secret_username:-$FOUNDRY_USERNAME}
   FOUNDRY_PASSWORD=${secret_password:-$FOUNDRY_PASSWORD}
   FOUNDRY_ADMIN_KEY=${secret_admin_key:-$FOUNDRY_ADMIN_KEY}
+  FOUNDRY_LICENSE_KEY${secret_license_key:-$FOUNDRY_LICENSE_KEY}
 fi
 
 # Check to see if an install is required
@@ -52,9 +55,9 @@ if [ $install_required = true ]; then
   if [[ "${FOUNDRY_USERNAME:-}" && "${FOUNDRY_PASSWORD:-}" ]]; then
     echo "Using FOUNDRY_USERNAME and FOUNDRY_PASSWORD to fetch release URL and license."
     if [[ "${CONTAINER_VERBOSE:-}" ]]; then
-      s3_url=$(./authenticate.js --log-level=trace --license=license.json "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}")
+      s3_url=$(./authenticate.js --log-level=trace --license "${FOUNDRY_LICENSE_KEY}" --license-filename=license.json "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}")
     else
-      s3_url=$(./authenticate.js --license=license.json "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}")
+      s3_url=$(./authenticate.js --license "${FOUNDRY_LICENSE_KEY}" --license-filename=license.json "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${FOUNDRY_VERSION}")
     fi
   elif [ "${FOUNDRY_RELEASE_URL:-}" ]; then
     echo "Using FOUNDRY_RELEASE_URL to download release."


### PR DESCRIPTION
# Added the option to provide a license key instead of retrieving it from foundryvtt.com

## 🗣 Description

`src/authenticate.js`:
- Changed the command line arguments in /src/authenticate.js to allow a parameter `--license=<LICE-NSEK-KEY>` and renamed the former `--license argument` to `--license-filename`
- If the `--license` parameter is not `""`, then it it used instead of parsing the license file webpage on foundryvtt.com
- The license is encoded and written to the file specified by the `--license-filename` (no change here)

`src/entrypoint.sh`:
- Added an option `foundry_license_key` to the secret file to provide the license key
- Adjusted the arguments to the call to `authenticate.js` to reflect the changes

## 💭 Motivation and Context

Addresses issue #53 

## 🧪 Testing

- Build the image locally and used `docker-compose run` with a missing and valid `FOUNDRY_LICENSE_KEY` in the docker-compose.yml` 
- **warn** Definitely needs a good second look as I am quite novice in docker

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (causes existing functionality to change)

Renaming of option `--license` to `--license-filename`, reusing `--license` to provide the license key

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [ ] My code follows the code style of this project (unfortunately not, my editor reformatted the files)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
