### PR TITLE
Drop permissions in a cleaner fashion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,9 @@ RUN apk --update --no-cache add curl jq sed su-exec tzdata
 WORKDIR ${FOUNDRY_HOME}
 
 COPY --from=optional-release-stage /root/dist/ .
-COPY src/entrypoint.sh src/package.json src/set_password.js src/authenticate.js \
-     src/get_release_url.js src/get_license.js src/logging.js ./
+COPY src/entrypoint.sh src/launcher.sh src/logging.sh src/package.json \
+     src/set_password.js src/authenticate.js src/get_release_url.js \
+     src/get_license.js src/logging.js ./
 RUN npm install && echo ${VERSION} > image_version.txt
 
 VOLUME ["/data"]

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -6,24 +6,13 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-# Define terminal colors for use in logger functions
-GREEN="\e[32m"
-RED="\e[31m"
-RESET="\e[0m"
-YELLOW="\e[33m"
-
-# Mimic the winston logging used in logging.js
-log(){
-  echo -e "Entrypoint | $(date +%Y-%m-%d\ %H:%M:%S) | [${GREEN}info${RESET}] $*"
-}
-
-log_warn(){
-  echo -e "Entrypoint | $(date +%Y-%m-%d\ %H:%M:%S) | [${YELLOW}warn${RESET}] $*"
-}
-
-log_error(){
-  echo -e "Entrypoint | $(date +%Y-%m-%d\ %H:%M:%S) | [${RED}error${RESET}] $*"
-}
+# setup logging
+# shellcheck disable=SC2034
+# LOG_NAME used in sourced file
+LOG_NAME="Entrypoint"
+# shellcheck disable=SC1091
+# disable following
+source logging.sh
 
 image_version=$(cat image_version.txt)
 
@@ -178,89 +167,19 @@ else
   log "Not modifying existing installation license key."
 fi
 
-if [ "$(id -u)" = 0 ]; then
-  # ensure the permissions are set correctly
-  log "Setting data directory permissions."
-  chown -R "${FOUNDRY_UID:-foundry}:${FOUNDRY_GID:-foundry}" /data
+# ensure the permissions are set correctly
+log "Setting data directory permissions."
+chown -R "${FOUNDRY_UID:-foundry}:${FOUNDRY_GID:-foundry}" /data
 
-  if [ "$1" = "--root-shell" ]; then
-    /bin/sh
-    exit $?
-  fi
-
-  if [ "${FOUNDRY_UID:-foundry}" != 0 ]; then
-    # drop privileges and restart this script as foundry user
-    log "Switching uid:gid to ${FOUNDRY_UID:-foundry}:${FOUNDRY_GID:-foundry} and restarting."
-    su-exec "${FOUNDRY_UID:-foundry}:${FOUNDRY_GID:-foundry}" "$(readlink -f "$0")" "$@"
-    exit 0
-  fi
-fi
-
-if [ "$1" = "--shell" ]; then
+if [ "$1" = "--root-shell" ]; then
   /bin/sh
   exit $?
 fi
 
-# Quote all strings for insertion into json
-# busybox does not implement ${VAR@Q} substitution to quote variables
-
-if [[ "${FOUNDRY_AWS_CONFIG:-}" ]]; then
-  if [[ $FOUNDRY_AWS_CONFIG == "true" ]];then
-    FOUNDRY_AWS_CONFIG=true
-  else
-    FOUNDRY_AWS_CONFIG=\"${FOUNDRY_AWS_CONFIG}\"
-  fi
-fi
-if [[ "${FOUNDRY_HOSTNAME:-}" ]]; then
-  FOUNDRY_HOSTNAME=\"${FOUNDRY_HOSTNAME}\"
-fi
-if [[ "${FOUNDRY_ROUTE_PREFIX:-}" ]]; then
-  FOUNDRY_ROUTE_PREFIX=\"${FOUNDRY_ROUTE_PREFIX}\"
-fi
-if [[ "${FOUNDRY_SSL_CERT:-}" ]]; then
-  FOUNDRY_SSL_CERT=\"${FOUNDRY_SSL_CERT}\"
-fi
-if [[ "${FOUNDRY_SSL_KEY:-}" ]]; then
-  FOUNDRY_SSL_KEY=\"${FOUNDRY_SSL_KEY}\"
-fi
-if [[ "${FOUNDRY_UPDATE_CHANNEL:-}" ]]; then
-  FOUNDRY_UPDATE_CHANNEL=\"${FOUNDRY_UPDATE_CHANNEL}\"
-fi
-if [[ "${FOUNDRY_WORLD:-}" ]]; then
-  FOUNDRY_WORLD=\"${FOUNDRY_WORLD}\"
-fi
-
-# Update configuration file
-mkdir -p /data/Config >& /dev/null
-log "Generating options.json file."
-cat <<EOF > /data/Config/options.json
-{
-  "awsConfig": ${FOUNDRY_AWS_CONFIG:-null},
-  "dataPath": "/data",
-  "fullscreen": false,
-  "hostname": ${FOUNDRY_HOSTNAME:-null},
-  "noUpdate": ${FOUNDRY_NO_UPDATE:-true},
-  "port": 30000,
-  "proxyPort": ${FOUNDRY_PROXY_PORT:-null},
-  "proxySSL": ${FOUNDRY_PROXY_SSL:-false},
-  "routePrefix": ${FOUNDRY_ROUTE_PREFIX:-null},
-  "sslCert": ${FOUNDRY_SSL_CERT:-null},
-  "sslKey": ${FOUNDRY_SSL_KEY:-null},
-  "updateChannel": ${FOUNDRY_UPDATE_CHANNEL:-\"release\"},
-  "upnp": ${FOUNDRY_UPNP:-false},
-  "world": ${FOUNDRY_WORLD:-null}
-}
-EOF
-
-# Save Admin Access Key if it is set
-if [[ "${FOUNDRY_ADMIN_KEY:-}" ]]; then
-  log "Setting 'Admin Access Key'."
-  echo "${FOUNDRY_ADMIN_KEY}" | ./set_password.js > /data/Config/admin.txt
-else
-  log_warn "Warning: No 'Admin Access Key' has been configured."
-  rm /data/Config/admin.txt >& /dev/null || true
-fi
-
-# Spawn node with clean environment to prevent credential leaks
-log "Starting Foundry Virtual Tabletop."
-env -i HOME="$HOME" node "$@"
+# drop privileges and handoff to launcher
+log "Starting launcher with uid:gid as ${FOUNDRY_UID:-foundry}:${FOUNDRY_GID:-foundry}."
+export FOUNDRY_ADMIN_KEY FOUNDRY_AWS_CONFIG FOUNDRY_HOSTNAME FOUNDRY_NO_UPDATE \
+  FOUNDRY_PROXY_PORT FOUNDRY_PROXY_SSL FOUNDRY_ROUTE_PREFIX FOUNDRY_SSL_CERT \
+  FOUNDRY_SSL_KEY FOUNDRY_UPDATE_CHANNEL FOUNDRY_UPNP FOUNDRY_WORLD
+su-exec "${FOUNDRY_UID:-foundry}:${FOUNDRY_GID:-foundry}" ./launcher.sh "$@"
+exit 0

--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# shellcheck disable=SC2039
+# busybox supports more features than POSIX /bin/sh
+
+# setup logging
+# shellcheck disable=SC2034
+# LOG_NAME used in sourced file
+LOG_NAME="Launcher"
+# shellcheck disable=SC1091
+# disable following
+source logging.sh
+
+if [ "$1" = "--shell" ]; then
+  /bin/sh
+  exit $?
+fi
+
+# Quote all strings for insertion into json
+# busybox does not implement ${VAR@Q} substitution to quote variables
+
+if [[ "${FOUNDRY_AWS_CONFIG:-}" ]]; then
+  if [[ $FOUNDRY_AWS_CONFIG == "true" ]];then
+    FOUNDRY_AWS_CONFIG=true
+  else
+    FOUNDRY_AWS_CONFIG=\"${FOUNDRY_AWS_CONFIG}\"
+  fi
+fi
+if [[ "${FOUNDRY_HOSTNAME:-}" ]]; then
+  FOUNDRY_HOSTNAME=\"${FOUNDRY_HOSTNAME}\"
+fi
+if [[ "${FOUNDRY_ROUTE_PREFIX:-}" ]]; then
+  FOUNDRY_ROUTE_PREFIX=\"${FOUNDRY_ROUTE_PREFIX}\"
+fi
+if [[ "${FOUNDRY_SSL_CERT:-}" ]]; then
+  FOUNDRY_SSL_CERT=\"${FOUNDRY_SSL_CERT}\"
+fi
+if [[ "${FOUNDRY_SSL_KEY:-}" ]]; then
+  FOUNDRY_SSL_KEY=\"${FOUNDRY_SSL_KEY}\"
+fi
+if [[ "${FOUNDRY_UPDATE_CHANNEL:-}" ]]; then
+  FOUNDRY_UPDATE_CHANNEL=\"${FOUNDRY_UPDATE_CHANNEL}\"
+fi
+if [[ "${FOUNDRY_WORLD:-}" ]]; then
+  FOUNDRY_WORLD=\"${FOUNDRY_WORLD}\"
+fi
+
+# Update configuration file
+mkdir -p /data/Config >& /dev/null
+log "Generating options.json file."
+cat <<EOF > /data/Config/options.json
+{
+  "awsConfig": ${FOUNDRY_AWS_CONFIG:-null},
+  "dataPath": "/data",
+  "fullscreen": false,
+  "hostname": ${FOUNDRY_HOSTNAME:-null},
+  "noUpdate": ${FOUNDRY_NO_UPDATE:-true},
+  "port": 30000,
+  "proxyPort": ${FOUNDRY_PROXY_PORT:-null},
+  "proxySSL": ${FOUNDRY_PROXY_SSL:-false},
+  "routePrefix": ${FOUNDRY_ROUTE_PREFIX:-null},
+  "sslCert": ${FOUNDRY_SSL_CERT:-null},
+  "sslKey": ${FOUNDRY_SSL_KEY:-null},
+  "updateChannel": ${FOUNDRY_UPDATE_CHANNEL:-\"release\"},
+  "upnp": ${FOUNDRY_UPNP:-false},
+  "world": ${FOUNDRY_WORLD:-null}
+}
+EOF
+
+# Save Admin Access Key if it is set
+if [[ "${FOUNDRY_ADMIN_KEY:-}" ]]; then
+  log "Setting 'Admin Access Key'."
+  echo "${FOUNDRY_ADMIN_KEY}" | ./set_password.js > /data/Config/admin.txt
+else
+  log_warn "No 'Admin Access Key' has been configured."
+  rm /data/Config/admin.txt >& /dev/null || true
+fi
+
+# Spawn node with clean environment to prevent credential leaks
+log "Starting Foundry Virtual Tabletop."
+env -i HOME="$HOME" node "$@"

--- a/src/logging.sh
+++ b/src/logging.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# shellcheck disable=SC2039
+# busybox supports more features than POSIX /bin/sh
+
+# Define terminal colors for use in logger functions
+GREEN="\e[32m"
+RED="\e[31m"
+RESET="\e[0m"
+YELLOW="\e[33m"
+
+# Mimic the winston logging used in logging.js
+log(){
+  echo -e "${LOG_NAME} | $(date +%Y-%m-%d\ %H:%M:%S) | [${GREEN}info${RESET}] $*"
+}
+
+log_warn(){
+  echo -e "${LOG_NAME} | $(date +%Y-%m-%d\ %H:%M:%S) | [${YELLOW}warn${RESET}] $*"
+}
+
+log_error(){
+  echo -e "${LOG_NAME} | $(date +%Y-%m-%d\ %H:%M:%S) | [${RED}error${RESET}] $*"
+}


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This fixes #56 

Thanks to @pdf for reporting.

- Create a launcher that will run with the requested uid:gid.
- Abstract out shell logging.

<!--- Describe your changes in detail -->

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- In some Docker versions the secrets mounts were `0600` instead of `0644` or `0444` as specified in the [secrets documentation](https://docs.docker.com/compose/compose-file/#long-syntax-2).  
- The relaunching of the entrypoint with new effective uid:gid was overly complicated.   This approach is simpler.


## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- CI test suite.
- Local dev testing.
- UAT by @pdf

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
