### PR TITLE
Replace noupdate error text with a container-specific message.

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -150,6 +150,15 @@ if [ $install_required = true ]; then
       log_warn "Container patches directory not found."
     fi
   fi
+
+  # Replace --noupdate error message with a container-specific one.
+  update_js="$FOUNDRY_HOME/resources/app/dist/update.js"
+  sed --file=- --in-place=.orig "${update_js}" << SED_SCRIPT
+s/'You[^']*--noupdate\\\\x20mode.'\
+/'This instance of Foundry Virtual Tabletop is running in a Docker container.  \
+To update, please pull a new Docker image and restart the container.'/g
+SED_SCRIPT
+
 fi  # install required
 
 if [ ! -f /data/Config/license.json ]; then


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

When a user currently tries to update the server software within the container they will see a less-than-helpful message since `--noupdate` is set in the `Dockerfile`.

> You are not allowed to update this instance of Foundry Virtual Tabletop because it was launched in `--noupdate` mode.

This is replaced now by a more helpful message:

> This instance of Foundry Virtual Tabletop is running in a Docker container.  To update, please pull a new Docker image and restart the container.


<!--- Describe your changes in detail -->

## 💭 Motivation and Context

A few users have been confused about the error message, and did not read the documentation.  Specifically the "update" section of the `README`.   This change should give them a better experience.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally and in CI.

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
