### PR TITLE
Removing exposed TURN ports.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,10 @@ VOLUME ["/data"]
 # HTTP Server
 EXPOSE 30000/TCP
 # TURN Server
-EXPOSE 33478/UDP
-EXPOSE 49152-65535/UDP
+# Not exposing TURN ports due to bug in Docker.
+# See: https://github.com/moby/moby/issues/11185
+# EXPOSE 33478/UDP
+# EXPOSE 49152-65535/UDP
 
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["resources/app/main.js", "--port=30000", "--headless", "--noupdate",\


### PR DESCRIPTION

# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->

See: https://github.com/moby/moby/issues/11185

Users of the Portainer frontend are publishing all exposed ports by 
default / accident.  This is causing lockups and crashes on their 
devices.  Since unexposed ports can still be published, and use of the 
internal TURN server is niche this change will save more pain than it 
will cause.  

This should be documented in a FAQ with the myriad issues Portainer can 
cause.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reported as a problem on the Foundry discord.

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally and in CI. 

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (To be documented in future FAQ)
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
