### PR TITLE
Always authenticate when credentials are provided

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,7 +339,7 @@ jobs:
   build-push-all:
     name: "Build and push all platforms"
     runs-on: ubuntu-latest
-    needs: [prepare, test-normal, test-pre-install]
+    needs: [lint, prepare, test-normal, test-pre-install]
     if: github.event_name != 'pull_request'
     steps:
       - name: Login to DockerHub

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -183,7 +183,7 @@ if [ ! -f /data/Config/license.json ]; then
     fi
     echo "{ \"license\": \"${fetched_license_key}\" }" > /data/Config/license.json
   else
-    log_warn "Unable to apply a license key since niether a license key nor credentials were provided.  The license key will need to be entered in the browser."
+    log_warn "Unable to apply a license key since neither a license key nor credentials were provided.  The license key will need to be entered in the browser."
   fi
   set -o nounset
 else


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

<!--- Describe your changes in detail -->

When `FOUNDRY_RELEASE_URL` is set with `FOUNDRY_USERNAME` and `FOUNDRY_PASSWORD` the container will use `FOUNDRY_RELEASE_URL` to fetch the distribution, but it will still authenticate so that it may apply a license to the server later if needed.  

## 💭 Motivation and Context

See:  #105 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Tested in various configurations locally. 
- CI

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
