### PR TITLE
Add debug logging to entrypoint and launcher scripts

### DIFF
--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -17,7 +17,7 @@ LOG_NAME="Launcher"
 source logging.sh
 
 # ensure the config directory exists
-log "Ensuring ${CONFIG_DIR} directory exists."
+log_debug "Ensuring ${CONFIG_DIR} directory exists."
 mkdir -p "${CONFIG_DIR}"
 
 if [[ "${CONTAINER_PRESERVE_CONFIG:-}" == "true" && -f "${CONFIG_FILE}" ]]; then

--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -17,7 +17,8 @@ LOG_NAME="Launcher"
 source logging.sh
 
 # ensure the config directory exists
-mkdir -p "${CONFIG_DIR}" >& /dev/null
+log "Ensuring ${CONFIG_DIR} directory exists."
+mkdir -p "${CONFIG_DIR}"
 
 if [[ "${CONTAINER_PRESERVE_CONFIG:-}" == "true" && -f "${CONFIG_FILE}" ]]; then
   log_warn "CONTAINER_PRESERVE_CONFIG is set: Not updating options.json"

--- a/src/logging.sh
+++ b/src/logging.sh
@@ -3,12 +3,19 @@
 # busybox supports more features than POSIX /bin/sh
 
 # Define terminal colors for use in logger functions
+BLUE="\e[34m"
 GREEN="\e[32m"
 RED="\e[31m"
 RESET="\e[0m"
 YELLOW="\e[33m"
 
 # Mimic the winston logging used in logging.js
+log_debug(){
+  if [[ "${CONTAINER_VERBOSE:-}" ]]; then
+    echo -e "${LOG_NAME} | $(date +%Y-%m-%d\ %H:%M:%S) | [${BLUE}debug${RESET}] $*"
+  fi
+}
+
 log(){
   echo -e "${LOG_NAME} | $(date +%Y-%m-%d\ %H:%M:%S) | [${GREEN}info${RESET}] $*"
 }


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Add debug logging to the entrypoint and launcher scripts to aid debugging efforts. 

## 💭 Motivation and Context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

When users have issues with the container they are often filesystem permission-based.
Discussion #124 

This PR allows the `CONTAINER_VERBOSE` environment variable to toggle additional logging in the shell scripts.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested locally, on CI, and with users in discussion #124 

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more un-checked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow project standards.
* [x] All relevant repo and/or project documentation has been updated to reflect
      the changes in this PR.
* [x] All new and existing tests pass.
