### PR TITLE
Add Container Patch URLS at build time

### DIFF
--- a/src/apply_patches.sh
+++ b/src/apply_patches.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+if [[ "${CONTAINER_PATCH_URLS:-}" ]]; then
+  source ./logging.sh
+
+  log_warn "CONTAINER_PATCH_URLS is set:  Only use patch URLs from trusted sources!"
+  for url in ${CONTAINER_PATCH_URLS}; do
+    log "Downloading patch from URL: $url"
+    patch_file=$(mktemp -t patch_url.sh.XXXXXX)
+    curl --silent --output "${patch_file}" "${url}"
+    log_debug "Sourcing patch file: ${patch_file}"
+    # shellcheck disable=SC1090
+    source "${patch_file}"
+  done
+  log "Completed URL patching."
+fi

--- a/src/apply_patches.sh
+++ b/src/apply_patches.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 if [[ "${CONTAINER_PATCH_URLS:-}" ]]; then
-  source ./logging.sh
+  source logging.sh
 
   log_warn "CONTAINER_PATCH_URLS is set:  Only use patch URLs from trusted sources!"
   for url in ${CONTAINER_PATCH_URLS}; do


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Adds apply_patches.sh to keep the Dockerfile from growing too complex.
Can be used in `entrypoint.sh` as well I imagine.

Changes the optional build step to write a `status.txt` out. Later use that file to 
know whether or not foundry was installed. I was unable to
find a way to detect this built into to Docker and multistage builds do
not persist environment variables across them. I am very open to other options.
Then read back the file to determine whether or not to run the Container
Patch URLs then remove it..

Container Patch URLs must be ran in the second stage because they may
rely on the `/data` directory existing and what not. Running in the
second step guarantees the same runtime environment they normally expect.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

See Issue #220 

## 🧪 Testing ##

Built an image with various permutations of having and not having patch urls and credentials. Build ran successfully in all cases.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more un-checked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced in code comments.
* [ ] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow project standards.
* [x] All relevant repo and/or project documentation has been updated to reflect
      the changes in this PR.
* [ ] Tests have been added to cover the changes in this PR.
* [x] All new and existing tests pass.
