### PR TITLE
Emit a friendly message when the installer type is wrong.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ RUN addgroup --system --gid ${FOUNDRY_UID} foundry \
   && adduser --system --uid ${FOUNDRY_UID} --ingroup foundry foundry \
   && apk --update --no-cache add \
   curl \
+  file \
   jq \
   sed \
   su-exec \

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -152,6 +152,32 @@ if [ $install_required = true ]; then
     mv "${downloading_filename}" "${release_filename}" > /dev/null 2>&1 || true
   fi
 
+  # Validate that the installer format looks correct. It's common to download
+  # the windows installer by accident, as that's the default installer in the
+  # foundryvtt.com licenses page.
+  release_type="$(file ${release_filename})"
+  case "${release_type}" in
+    *"Zip archive data"*)
+      log_debug "${release_filename} is a valid zip file and looks like a Linux/NodeJS installer."
+      ;;
+    *"PE32 executable"*)
+      log_error "${release_filename} is a PE32 executable and looks like a Windows installer."
+      log_error "If downloading via FOUNDRY_RELEASE_URL, make sure to pick the right"
+      log_error "operating system in the foundryvtt.com licenses page."
+      exit 1
+      ;;
+    *"zlib compressed data"*)
+      log_error "${release_filename} is a zlib compressed file and looks like a MacOS installer."
+      log_error "If downloading via FOUNDRY_RELEASE_URL, make sure to pick the right"
+      log_error "operating system in the foundryvtt.com licenses page."
+      exit 1
+      ;;
+    *)
+      log_error "${release_type}"
+      log_error "${release_filename} has an unexpected file format, try downloading again."
+      ;;
+  esac
+
   if [ -f "${release_filename}" ]; then
     log "Installing Foundry Virtual Tabletop ${FOUNDRY_VERSION}"
     unzip -q "${release_filename}" 'resources/*'

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -177,6 +177,7 @@ if [ $install_required = true ]; then
       *)
         log_error "${release_type}"
         log_error "${release_filename} has an unexpected file format, try downloading again."
+        exit 1
         ;;
     esac
     unzip -q "${release_filename}" 'resources/*'

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -159,22 +159,22 @@ if [ $install_required = true ]; then
       *"Zip archive data"*)
         log_debug "${release_filename} is a valid zip file and looks like a Linux/NodeJS installer."
         ;;
-      *"PE31 executable"*)
-        log_error "${release_filename} is a PE31 executable and looks like a Windows installer."
+      *"PE32 executable"*)
+        log_error "${release_filename} is a PE32 executable and looks like a Windows installer."
         log_error "If downloading via FOUNDRY_RELEASE_URL, make sure to pick the right"
         log_error "operating system in the foundryvtt.com licenses page."
-        exit 0
+        exit 1
         ;;
       *"zlib compressed data"*)
         log_error "${release_filename} is a zlib compressed file and looks like a MacOS installer."
         log_error "If downloading via FOUNDRY_RELEASE_URL, make sure to pick the right"
         log_error "operating system in the foundryvtt.com licenses page."
-        exit 0
+        exit 1
         ;;
       *)
         log_error "${release_type}"
         log_error "${release_filename} has an unexpected file format, try downloading again."
-        exit 0
+        exit 1
         ;;
     esac
   fi

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -150,10 +150,7 @@ if [ $install_required = true ]; then
     # Rename the download now that it is completed.
     # If we had a cache hit, the file is already renamed.
     mv "${downloading_filename}" "${release_filename}" > /dev/null 2>&1 || true
-  fi
 
-  if [ -f "${release_filename}" ]; then
-    log "Installing Foundry Virtual Tabletop ${FOUNDRY_VERSION}"
     # Validate that the installer format looks correct. It's common to download
     # the windows installer by accident, as that's the default installer in the
     # foundryvtt.com licenses page.
@@ -162,24 +159,28 @@ if [ $install_required = true ]; then
       *"Zip archive data"*)
         log_debug "${release_filename} is a valid zip file and looks like a Linux/NodeJS installer."
         ;;
-      *"PE32 executable"*)
-        log_error "${release_filename} is a PE32 executable and looks like a Windows installer."
+      *"PE31 executable"*)
+        log_error "${release_filename} is a PE31 executable and looks like a Windows installer."
         log_error "If downloading via FOUNDRY_RELEASE_URL, make sure to pick the right"
         log_error "operating system in the foundryvtt.com licenses page."
-        exit 1
+        exit 0
         ;;
       *"zlib compressed data"*)
         log_error "${release_filename} is a zlib compressed file and looks like a MacOS installer."
         log_error "If downloading via FOUNDRY_RELEASE_URL, make sure to pick the right"
         log_error "operating system in the foundryvtt.com licenses page."
-        exit 1
+        exit 0
         ;;
       *)
         log_error "${release_type}"
         log_error "${release_filename} has an unexpected file format, try downloading again."
-        exit 1
+        exit 0
         ;;
     esac
+  fi
+
+  if [ -f "${release_filename}" ]; then
+    log "Installing Foundry Virtual Tabletop ${FOUNDRY_VERSION}"
     unzip -q "${release_filename}" 'resources/*'
     log_debug "Installation completed."
   else

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -152,34 +152,33 @@ if [ $install_required = true ]; then
     mv "${downloading_filename}" "${release_filename}" > /dev/null 2>&1 || true
   fi
 
-  # Validate that the installer format looks correct. It's common to download
-  # the windows installer by accident, as that's the default installer in the
-  # foundryvtt.com licenses page.
-  release_type="$(file "${release_filename}")"
-  case "${release_type}" in
-    *"Zip archive data"*)
-      log_debug "${release_filename} is a valid zip file and looks like a Linux/NodeJS installer."
-      ;;
-    *"PE32 executable"*)
-      log_error "${release_filename} is a PE32 executable and looks like a Windows installer."
-      log_error "If downloading via FOUNDRY_RELEASE_URL, make sure to pick the right"
-      log_error "operating system in the foundryvtt.com licenses page."
-      exit 1
-      ;;
-    *"zlib compressed data"*)
-      log_error "${release_filename} is a zlib compressed file and looks like a MacOS installer."
-      log_error "If downloading via FOUNDRY_RELEASE_URL, make sure to pick the right"
-      log_error "operating system in the foundryvtt.com licenses page."
-      exit 1
-      ;;
-    *)
-      log_error "${release_type}"
-      log_error "${release_filename} has an unexpected file format, try downloading again."
-      ;;
-  esac
-
   if [ -f "${release_filename}" ]; then
     log "Installing Foundry Virtual Tabletop ${FOUNDRY_VERSION}"
+    # Validate that the installer format looks correct. It's common to download
+    # the windows installer by accident, as that's the default installer in the
+    # foundryvtt.com licenses page.
+    release_type="$(file "${release_filename}")"
+    case "${release_type}" in
+      *"Zip archive data"*)
+        log_debug "${release_filename} is a valid zip file and looks like a Linux/NodeJS installer."
+        ;;
+      *"PE32 executable"*)
+        log_error "${release_filename} is a PE32 executable and looks like a Windows installer."
+        log_error "If downloading via FOUNDRY_RELEASE_URL, make sure to pick the right"
+        log_error "operating system in the foundryvtt.com licenses page."
+        exit 1
+        ;;
+      *"zlib compressed data"*)
+        log_error "${release_filename} is a zlib compressed file and looks like a MacOS installer."
+        log_error "If downloading via FOUNDRY_RELEASE_URL, make sure to pick the right"
+        log_error "operating system in the foundryvtt.com licenses page."
+        exit 1
+        ;;
+      *)
+        log_error "${release_type}"
+        log_error "${release_filename} has an unexpected file format, try downloading again."
+        ;;
+    esac
     unzip -q "${release_filename}" 'resources/*'
     log_debug "Installation completed."
   else

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -155,7 +155,7 @@ if [ $install_required = true ]; then
   # Validate that the installer format looks correct. It's common to download
   # the windows installer by accident, as that's the default installer in the
   # foundryvtt.com licenses page.
-  release_type="$(file ${release_filename})"
+  release_type="$(file "${release_filename}")"
   case "${release_type}" in
     *"Zip archive data"*)
       log_debug "${release_filename} is a valid zip file and looks like a Linux/NodeJS installer."


### PR DESCRIPTION
## 🗣 Description ##

See https://github.com/felddy/foundryvtt-docker/issues/282 for
details. The short version is that it's a common error when using
FOUNDRY_RELEASE_URL to download the windows installer. Previously
a confusing message was emitted by the unzip command when that
happened. This gives a message that should help beginners understand
their mistake in choosing the wrong installer type.

## 💭 Motivation and Context ##

See https://github.com/felddy/foundryvtt-docker/issues/282

## 🧪 Testing ##

I haven't run this end-to-end at all yet, I just set up a little sandbox directory
to test the case statement against some sample files.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [ ] These code changes follow project standards.
* [ ] All relevant repo and/or project documentation has been updated to reflect
      the changes in this PR.
* [ ] Tests have been added to cover the changes in this PR.
* [ ] All new and existing tests pass.
