### PR TITLE
Add test skip if not running in GitHub Actions

### DIFF
--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -104,6 +104,12 @@ def test_log_version(version_container):
     ), f"Container version output to log does not match project version file {VERSION_FILE}"
 
 
+# The container version label is added during the GitHub Actions build workflow.
+# It will not be present if the container is built locally.
+# Skip this check if we are not running in GitHub Actions.
+@pytest.mark.skipif(
+    os.environ.get("GITHUB_ACTIONS") != "true", reason="not running in GitHub Actions"
+)
 def test_container_version_label_matches(version_container):
     """Verify the container version label is the correct version."""
     pkg_vars = {}
@@ -112,4 +118,4 @@ def test_container_version_label_matches(version_container):
     project_version = pkg_vars["__version__"]
     assert (
         version_container.labels["org.opencontainers.image.version"] == project_version
-    ), "Dockerfile version label does not match project version"
+    ), "Container version label does not match project version"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Skip the container version test if running tests outside of GitHub Actions.

## 💭 Motivation and Context ##

Some container labels are only present when calculated during the GitHub Actions workflow.  That is, they are not part of the
`Dockerfile`.   This PR skips tests of these labels when running outside of a GitHub Actions context.  

See: 
https://github.com/felddy/foundryvtt-docker/blob/7a964aa6995d62b58734759a8d4454d3b308e2f3/.github/workflows/build.yml#L242-L264

https://github.com/felddy/foundryvtt-docker/blob/7a964aa6995d62b58734759a8d4454d3b308e2f3/Dockerfile#L59-L61

To determine if the test is running in a GitHub Actions workflow we check for the `GITHUB_ACTIONS` environment variable.

See: https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables

## 🧪 Testing ##

Tested on my local development box with `GITHUB_ACTIONS` environment variable set and unset.  Also by GitHub Actions itself. 

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more un-checked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow project standards.
* [x] All relevant repo and/or project documentation has been updated to reflect
      the changes in this PR.
* [x] Tests have been added to cover the changes in this PR.
* [ ] All new and existing tests pass.
