### PR TITLE
Fail fast during testing

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -137,7 +137,7 @@ if [ $install_required = true ]; then
     log_debug "Installation completed."
   else
     log_error "Unable to install Foundry Virtual Tabletop!"
-    log_error "Either set set FOUNDRY_RELEASE_URL."
+    log_error "Either set FOUNDRY_RELEASE_URL."
     log_error "Or set FOUNDRY_USERNAME and FOUNDRY_PASSWORD."
     log_error "Or set CONTAINER_CACHE to a directory containing foundryvtt-${FOUNDRY_VERSION}.zip"
     exit 1

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -40,6 +40,8 @@ def test_wait_for_ready(main_container):
     # This could take a while, as we download the application.
     TIMEOUT = 180
     for i in range(TIMEOUT):
+        # Verify the container is still running
+        assert main_container.is_running is True, "The container unexpectedly exited."
         logs = main_container.logs().decode("utf-8")
         if READY_MESSAGE in logs:
             break
@@ -58,6 +60,8 @@ def test_wait_for_healthy(main_container):
     # This could take a while
     TIMEOUT = 180
     for i in range(TIMEOUT):
+        # Verify the container is still running
+        assert main_container.is_running is True, "The container unexpectedly exited."
         inspect = main_container.inspect()
         status = inspect["State"]["Health"]["Status"]
         assert status != "unhealthy", "The container became unhealthy."

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -74,11 +74,9 @@ def test_wait_for_healthy(main_container):
         )
 
 
-def test_wait_for_exits(main_container, version_container):
-    """Wait for containers to exit."""
-    assert (
-        version_container.wait() == 0
-    ), "Container service (version) did not exit cleanly"
+def test_wait_for_version_container_exit(version_container):
+    """Wait for version container to exit cleanly."""
+    assert version_container.wait() == 0, "The version container did not exit cleanly"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Allows tests to fail when the container exits due to an error.  
Also fixes a typo in an error message.

## 💭 Motivation and Context ##

Dependabot PRs that did not have access to secrets would would wait for a timeout instead of failing at exit.
This will speed up CI testing when there are credential errors.

## 🧪 Testing ##

Tested locally and in CI. 

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow project standards.
* [x] All relevant repo and/or project documentation has been updated to reflect
      the changes in this PR.
* [x] Tests have been added to cover the changes in this PR.
* [x] All new and existing tests pass.
