### PR TITLE
Fix linter bit rot detected in nightly builds

### DIFF
--- a/.github/lineage.yml
+++ b/.github/lineage.yml
@@ -2,3 +2,4 @@
 lineage:
   skeleton:
     remote-url: https://github.com/cisagov/skeleton-docker.git
+version: '1'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,7 +95,7 @@ repos:
         name: bandit (everything else)
         exclude: tests
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The `black` linter died.  Required an update.
Restored a clobbered `version` identifier in lineage configuration.

## 💭 Motivation and Context ##

CI was reporting failures.  Cause documented here: https://github.com/psf/black/issues/2964
Lineage was found to be broken when `setup-env` was run to test linter changes.  Restored `version` identifier. 

## 🧪 Testing ##

Locally and in CI. 

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow project standards.
* [x] All new and existing tests pass.
