### PR TITLE
Environment variable whitelist for clean node environent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Dockerfile-x
 license.json
 node_modules
 package-lock.json
+venv

--- a/README.md
+++ b/README.md
@@ -260,6 +260,19 @@ secrets](#using-secrets) instead of environment variables.
 |------------------|----------|
 | `FOUNDRY_RELEASE_URL` | S3 pre-signed URL generate from the user's profile.  Required for downloading an application distribution. |
 
+### Node variables ###
+
+Any
+[Node variables](https://nodejs.org/docs/latest-v16.x/api/cli.html#environment-variables)
+(`NODE_*`) supplied to the container will be passed to the Node server instance
+running FoundryVTT. Included below are some which are particularly useful.
+
+| Name | Purpose | Default |
+|------|---------|---------|
+| `NODE_EXTRA_CA_CERTS` | When set, the well known "root" CAs (like VeriSign) will be extended with the extra certificates. The file should consist of one or more trusted certificates in PEM format. A message will be emitted (once) with `process.emitWarning()` if the file is missing or malformed, but any errors are otherwise ignored. | |
+| `NODE_OPTIONS` | A space-separated list of command-line options that are interpreted before command-line options, so command-line options will override or compound after anything supplied. Node.js will exit with an error if an option that is not allowed in the environment is used, such as `-p` or a script file. | |
+| `NODE_TLS_REJECT_UNAUTHORIZED` | If the value equals `0`, certificate validation is disabled for TLS connections. This makes TLS, and HTTPS by extension, insecure. The use of this environment variable is strongly discouraged. | |
+
 ### Optional ###
 
 | Name  | Purpose | Default |

--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -60,13 +60,12 @@ fi
 
 # Space seperated list of regex rules which environment variables must meet to
 # be carried over to the new environment, which Node/Foundry will be running in.
-# All rules have ^ prefixed by default.
-ENV_VAR_WHITELIST='HOME NODE_';
+ENV_VAR_WHITELIST='^HOME$ ^NODE_.+$';
 # Build list of environment variables to carry over into a clean environment
 ENV_VAR_CARRY_LIST=''
 while IFS='=' read -rd '' ENV_VAR_NAME ENV_VAR_VALUE; do
   for VAR_REGEX in $ENV_VAR_WHITELIST; do
-    if [[ $ENV_VAR_NAME =~ ^"${VAR_REGEX}" ]]; then
+    if [[ $ENV_VAR_NAME =~ "${VAR_REGEX}" ]]; then
       ENV_VAR_CARRY_LIST="${ENV_VAR_CARRY_LIST} ${ENV_VAR_NAME}=${ENV_VAR_VALUE}"
       break
     fi

--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -60,12 +60,12 @@ fi
 
 # Space seperated list of regex rules which environment variables must meet to
 # be carried over to the new environment, which Node/Foundry will be running in.
-ENV_VAR_WHITELIST='^HOME$ ^NODE_.+$';
+ENV_VAR_WHITELIST='^HOME$ ^NODE_.+$'
 # Build list of environment variables to carry over into a clean environment
 ENV_VAR_CARRY_LIST=''
 while IFS='=' read -rd '' ENV_VAR_NAME ENV_VAR_VALUE; do
   for VAR_REGEX in $ENV_VAR_WHITELIST; do
-    if [[ $ENV_VAR_NAME =~ "${VAR_REGEX}" ]]; then
+    if [[ $ENV_VAR_NAME =~ ${VAR_REGEX} ]]; then
       ENV_VAR_CARRY_LIST="${ENV_VAR_CARRY_LIST} ${ENV_VAR_NAME}=${ENV_VAR_VALUE}"
       break
     fi
@@ -74,4 +74,6 @@ done < <(env -0)
 
 # Spawn node with clean environment to prevent credential leaks
 log "Starting Foundry Virtual Tabletop."
+# We want ENV_VAR_CARRY_LIST to word split
+# shellcheck disable=SC2086
 env -i $ENV_VAR_CARRY_LIST node "$@" || log_error "Node process exited with code $?"

--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -58,6 +58,21 @@ if [[ "${FOUNDRY_IP_DISCOVERY:-}" == "false" ]]; then
   set -- "$@" --noipdiscovery
 fi
 
+# Space seperated list of regex rules which environment variables must meet to
+# be carried over to the new environment, which Node/Foundry will be running in.
+# All rules have ^ prefixed by default.
+ENV_VAR_WHITELIST='HOME NODE_';
+# Build list of environment variables to carry over into a clean environment
+ENV_VAR_CARRY_LIST=''
+while IFS='=' read -rd '' ENV_VAR_NAME ENV_VAR_VALUE; do
+  for VAR_REGEX in $ENV_VAR_WHITELIST; do
+    if [[ $ENV_VAR_NAME =~ ^"${VAR_REGEX}" ]]; then
+      ENV_VAR_CARRY_LIST="${ENV_VAR_CARRY_LIST} ${ENV_VAR_NAME}=${ENV_VAR_VALUE}"
+      break
+    fi
+  done
+done < <(env -0)
+
 # Spawn node with clean environment to prevent credential leaks
 log "Starting Foundry Virtual Tabletop."
-env -i HOME="$HOME" node "$@" || log_error "Node process exited with code $?"
+env -i $ENV_VAR_CARRY_LIST node "$@" || log_error "Node process exited with code $?"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Solves (#317) by removing all environment variables that do not match a set of regex filter rules. Currently `HOME` and `NODE_` rules are allowed.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

See #317 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I have tested locally by passing `NODE_TLS_REJECT_UNAUTHORIZED` (Which causes an warning message if Node sees it, which it did), and have tested my logic on the command line in the container using the `--root-shell` flag.

All linting tests also pass.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more un-checked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow project standards.
* [x] All relevant repo and/or project documentation has been updated to reflect
      the changes in this PR.
* [x] Tests have been added to cover the changes in this PR.
* [ ] All new and existing tests pass.
