### PR TITLE
Add checks for unset repository secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,6 +217,28 @@ jobs:
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@8b4e4ac71822ed7e0ad5fb3d1c33483e9e8fb270
         if: github.event.inputs.remote-shell == 'true' || env.RUN_TMATE
+  check-docker-secrets:
+    name: "Check Docker secrets"
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-secrets
+        run: |
+          if [ -z "${{ secrets.DOCKER_USERNAME }}" ] ||
+            [ -z "${{ secrets.DOCKER_PASSWORD }}" ]; then
+            echo "::warning::Set DOCKER_USERNAME and DOCKER_PASSWORD secrets."
+            exit 1
+          fi
+  check-foundry-secrets:
+    name: "Check Foundry secrets"
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-secrets
+        run: |
+          if [ -z "${{ secrets.FOUNDRY_USERNAME }}" ] ||
+            [ -z "${{ secrets.FOUNDRY_PASSWORD }}" ]; then
+            echo "::warning::Set FOUNDRY_USERNAME and FOUNDRY_PASSWORD secrets."
+            exit 1
+          fi
   build-normal:
     # Builds a single test image for the native platform.  This image is saved
     # as an artifact and loaded by the test job.
@@ -297,7 +319,7 @@ jobs:
   build-pre-install:
     name: "Build pre-installed test image"
     runs-on: ubuntu-latest
-    needs: [prepare]
+    needs: [prepare, check-foundry-secrets]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9b0655f430fba8c7001d4e38f8d4306db5c6e0ab
@@ -375,7 +397,7 @@ jobs:
     # Executes tests on the single-platform image created in the "build" job.
     name: "Test normal image"
     runs-on: ubuntu-latest
-    needs: [build-normal]
+    needs: [build-normal, check-foundry-secrets]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9b0655f430fba8c7001d4e38f8d4306db5c6e0ab
@@ -496,7 +518,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: [lint, prepare, test-normal, test-pre-install]
+    needs: [lint, prepare, test-normal, test-pre-install, check-docker-secrets]
     if: github.event_name != 'pull_request'
     steps:
       - name: Harden Runner


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR adds jobs to the build workflow that verifies that Docker and Foundry secrets are present.
If the secrets are not available, the jobs that require the secrets will be skipped, and informative
error messages are emitted. 

## 💭 Motivation and Context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

PRs from forks do not have access to repository secrets.
The CI UI did not make it obvious why the jobs were failing.
These extra jobs clearly throw errors into the annotations describing the problem.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested with GitHub actions by unsetting the `FOUNDRY_USERNAME`. 

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->
![image](https://user-images.githubusercontent.com/3229435/163891335-909e1369-772f-4dea-b887-f4a9fc3e5eb0.png)

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more un-checked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow project standards.
* [x] All relevant repo and/or project documentation has been updated to reflect
      the changes in this PR.
* [x] All new and existing tests pass.
