### PR TITLE
Fix the static file compression parameter name

### DIFF
--- a/src/set_options.ts
+++ b/src/set_options.ts
@@ -39,14 +39,13 @@ if (process.env.FOUNDRY_DEMO_CONFIG) {
 
 let options: object = {
   awsConfig: process.env.FOUNDRY_AWS_CONFIG || null,
+  compressStatic: process.env.FOUNDRY_MINIFY_STATIC_FILES == "true",
   dataPath: DATA_PATH,
   demo: parsedDemoConfig,
   fullscreen: false,
   hostname: process.env.FOUNDRY_HOSTNAME || null,
   language: process.env.FOUNDRY_LANGUAGE || LANGUAGE,
   localHostname: process.env.FOUNDRY_LOCAL_HOSTNAME || null,
-  minifyStaticFiles: process.env.FOUNDRY_MINIFY_STATIC_FILES == "true",
-  compressStatic: process.env.FOUNDRY_MINIFY_STATIC_FILES == "true",
   passwordSalt: process.env.FOUNDRY_PASSWORD_SALT || null,
   port: FOUNDRY_PORT,
   protocol: process.env.FOUNDRY_PROTOCOL || null,

--- a/src/set_options.ts
+++ b/src/set_options.ts
@@ -46,6 +46,7 @@ let options: object = {
   language: process.env.FOUNDRY_LANGUAGE || LANGUAGE,
   localHostname: process.env.FOUNDRY_LOCAL_HOSTNAME || null,
   minifyStaticFiles: process.env.FOUNDRY_MINIFY_STATIC_FILES == "true",
+  compressStatic: process.env.FOUNDRY_MINIFY_STATIC_FILES == "true",
   passwordSalt: process.env.FOUNDRY_PASSWORD_SALT || null,
   port: FOUNDRY_PORT,
   protocol: process.env.FOUNDRY_PROTOCOL || null,


### PR DESCRIPTION
Fix static file support in v10

## 🗣 Description ##

Allows static file compression to be controlled from the docker config again.

## 💭 Motivation and context ##

`FOUNDRY_MINIFY_STATIC_FILES` no longer works in v10

## 🧪 Testing ##

After making the change the verified that the switch in the Foundry config screen track the value defined in `FOUNDRY_MINIFY_STATIC_FILES`.

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).


