### PR TITLE
Disable Python buffering when running pytest

### DIFF
--- a/.github/workflows/_test-image.yml
+++ b/.github/workflows/_test-image.yml
@@ -110,6 +110,7 @@ jobs:
         env:
           FOUNDRY_PASSWORD: ${{ secrets.foundry_password }}
           FOUNDRY_USERNAME: ${{ secrets.foundry_username }}
+          PYTHONUNBUFFERED: 1
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: pytest | tee data/pytests.log
       - name: Compress and encrypt data directory


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR adds the `PYTHONUNBUFFERED` to the execution of `pytest` in testing workflow.  

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

When Python is outputting to a `tee` it uses buffering.  This prevents the GitHub workflow from displaying the logs live.   

`tee` was added here: https://github.com/felddy/foundryvtt-docker/commit/e92beefb6b4d2cc51ad1c9b12ed0a7b2d39f7e5c

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Checked in push action log and noted streaming output had been restored. 

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

