### PR TITLE
Add endpoints for crazy-max/ghaction-dump-context

### DIFF
--- a/.github/workflows/_config.yml
+++ b/.github/workflows/_config.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            azure.archive.ubuntu.com:443
+            azure.archive.ubuntu.com:80
+            packages.microsoft.com:443
             www.githubstatus.com:443
 
       - name: Check GitHub Status


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Diagnostic job now requires additional endpoint access.

See:
- https://github.com/crazy-max/ghaction-dump-context/pull/12

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Fixes breakage from upstream change.

