### PR TITLE
Improve token permissions and runner hardening

### DIFF
--- a/.github/workflows/_config.yml
+++ b/.github/workflows/_config.yml
@@ -33,6 +33,9 @@ on:
         description: "The platform to use for testing"
         value: linux/amd64
 
+permissions:
+  contents: read
+
 jobs:
   diagnostics:
     name: "Diagnostics"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,11 @@ jobs:
     name: "Foundry secrets"
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776
+        with:
+          egress-policy: block
+
       - name: Check foundry.com credentials
         run: |
           return_code=0
@@ -55,6 +60,11 @@ jobs:
     name: "Docker secrets"
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776
+        with:
+          egress-policy: block
+
       - name: Check docker.com credentials
         run: |
           return_code=0
@@ -72,6 +82,11 @@ jobs:
     name: "Artifact key"
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776
+        with:
+          egress-policy: block
+
       - name: Check artifact key
         run: |
           if [ -z "${{ secrets.ARTIFACT_KEY }}" ]; then

--- a/.github/workflows/docker-pytest-image.yml
+++ b/.github/workflows/docker-pytest-image.yml
@@ -63,6 +63,9 @@ env:
   ARTIFACT_WORK_DIR: /tmp/artifact-work
   TEST_IMAGE_TAG: test-image:latest
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # Executes tests on the single-platform image created in the "build" job.


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Applies some changes that were flagged by the Scorecard security scanning:

- add top-level permissions to GitHub Actions workflows where needed
- add hardened runners to credential and key job checks

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

The quest to maintain security without sacrificing usability.  

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

GitHub Actions testing.   Can't really be tested locally.  

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
