### PR TITLE
Add SBOM generation to workflows and releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,7 @@ jobs:
       image_archive_key: ${{ secrets.ARTIFACT_KEY }}
 
   build-each-platform:
+    name: "Build platform"
     needs:
       - config
       - lint
@@ -192,7 +193,6 @@ jobs:
         platform: ${{ fromJson(needs.config.outputs.platforms_json) }}
         exclude:
           - platform: ${{ needs.config.outputs.test_platform }}
-    name: "${{ matrix.platform }}"
     uses: felddy/reusable-workflows/.github/workflows/docker-build-image.yml@develop
     with:
       artifact_name: ${{ needs.config.outputs.image_archive_artifact_name }}
@@ -217,13 +217,13 @@ jobs:
       image_artifact_name: ${{ needs.config.outputs.image_archive_artifact_name }}
 
   build-multi-arch-image:
+    name: "Publish image"
     needs:
       - build-each-platform
       - config
       - docker-secrets
       - metadata
     if: github.event_name != 'pull_request'
-    name: "Publish image"
     permissions:
       packages: write
     uses: felddy/reusable-workflows/.github/workflows/docker-multi-arch-push.yml@develop
@@ -235,13 +235,13 @@ jobs:
       docker_username: ${{ secrets.DOCKER_USERNAME }}
 
   publish-readme:
+    name: "Publish docs"
     needs:
       - build-multi-arch-image
       - config
       - docker-secrets
       - metadata
     if: needs.metadata.outputs.is_latest == 'true'
-    name: "Publish docs"
     uses: felddy/reusable-workflows/.github/workflows/docker-publish-description.yml@develop
     with:
       image_name: ${{ needs.config.outputs.image_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,17 @@ jobs:
       build_args: |
         VERSION=${{ needs.metadata.outputs.source_version }}
 
+  generate-sboms:
+    name: "Bill of Materials"
+    needs:
+      - build-each-platform
+      - config
+    permissions:
+      contents: write
+    uses: felddy/reusable-workflows/.github/workflows/sbom-artifact.yml@develop
+    with:
+      image_artifact_name: ${{ needs.config.outputs.image_archive_artifact_name }}
+
   build-multi-arch-image:
     needs:
       - build-each-platform


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR adds SBOM generation for each supported platform.
The SBOMs will be attached in an artifact for the workflow that generated the images.
If the workflow is part of a release or tag, the the SBOMs will be attached individually as assets to the release.
It also, cleans up some of the `name` tags in the build workflow.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

A “software bill of materials” (SBOM) has emerged as a key building block in software security and software supply chain risk management. A SBOM is a nested inventory, a list of ingredients that make up software components.

See: 
- https://www.cisa.gov/sbom
- https://ntia.gov/page/software-bill-materials

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested in ci-testing repository and in the v11 branch.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
