### PR TITLE
Update get_license tool for new license page format

### DIFF
--- a/src/get_license.ts
+++ b/src/get_license.ts
@@ -76,11 +76,13 @@ async function fetchLicenses(username: string): Promise<string[]> {
   const body = await response.text();
   const $ = await cheerio.load(body);
 
-  const licenses: string[] = $("pre.key-code code")
+  const licenses: string[] = $("div.license label.copy input")
     .map(function (this: cheerio.Element) {
-      return $(this).text().replace(/-/g, ""); // remove dashes
+      const value = $(this).attr("value");
+      return value ? value.replace(/-/g, "") : undefined; // remove dashes
     })
-    .get();
+    .get()
+    .filter(Boolean);
   return licenses;
 }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR updates the `get_license.ts` tool to extract licenses from the new foundryvtt.com license page format.

Resolves #669 


## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

License extraction broke after the site update yesterday.
The code was updated to select the new location of the license on the page.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested locally and in CI.  
Note, since I only have once license, I had to make some assumptions about how the page is rendered with multiple licenses. 
It is possible that these assumptions were incorrect.


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
