### PR TITLE
Remove enabling init in compose examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ configuration files, set `CONTAINER_PRESERVE_CONFIG` to `true`.
       foundry:
         image: felddy/foundryvtt:release
         hostname: my_foundry_host
-        init: true
         volumes:
           - type: bind
             source: <your_data_dir>
@@ -150,7 +149,6 @@ uses `secrets.json`.  Regardless of the name you choose it must be targeted to
       foundry:
         image: felddy/foundryvtt:release
         hostname: my_foundry_host
-        init: true
         volumes:
           - type: bind
             source: <your_data_dir>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
   foundry:
     image: felddy/foundryvtt:release
     hostname: my_foundry_host
-    init: true
     restart: "no"
     volumes:
       - type: bind


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Updates documentation to remove examples that enable `init`.  

Closes #685 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

See:
- #685


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
