### PR TITLE
Use new reusable workflow build argument passing mechanism

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,7 +243,7 @@ jobs:
       - config
       - docker-secrets
       - metadata
-    if: needs.metadata.outputs.is_latest == 'true'
+    if: needs.metadata.outputs.latest == 'true'
     uses: felddy/reusable-workflows/.github/workflows/docker-publish-description.yml@develop
     with:
       image_name: ${{ needs.config.outputs.image_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,14 +108,14 @@ jobs:
     uses: felddy/reusable-workflows/.github/workflows/docker-build-image.yml@develop
     with:
       artifact_name: ${{ needs.config.outputs.image_archive_artifact_name }}
+      build_arg_1_name: VERSION
       cache_from_scopes: ${{ needs.config.outputs.test_platform }}
       cache_to_scope: ${{ needs.config.outputs.test_platform }}
       image_archive_name_stem: ${{ needs.config.outputs.test_platform }}
       image_labels: ${{ needs.metadata.outputs.image_labels }}
       platforms: ${{ needs.config.outputs.test_platform }}
     secrets:
-      build_args: |
-        VERSION=${{ needs.metadata.outputs.source_version }}
+      build_arg_1_value: ${{ needs.metadata.outputs.source_version }}
 
   build-pre-installed-test-image:
     name: "Build pre-installed test image"
@@ -128,17 +128,19 @@ jobs:
     uses: felddy/reusable-workflows/.github/workflows/docker-build-image.yml@develop
     with:
       artifact_name: ${{ needs.config.outputs.image_archive_artifact_name }}-pre-installed
+      build_arg_1_name: FOUNDRY_PASSWORD
+      build_arg_2_name: FOUNDRY_USERNAME
+      build_arg_3_name: VERSION
       cache_from_scopes: ${{ needs.config.outputs.test_platform }}-pre-installed
       cache_to_scope: ${{ needs.config.outputs.test_platform }}-pre-installed
       image_archive_name_stem: ${{ needs.config.outputs.test_platform }}
       image_labels: ${{ needs.metadata.outputs.image_labels }}
       platforms: ${{ needs.config.outputs.test_platform }}
     secrets:
+      build_arg_1_value: ${{ secrets.FOUNDRY_PASSWORD }}
+      build_arg_2_value: ${{ secrets.FOUNDRY_USERNAME }}
+      build_arg_3_value: ${{ needs.metadata.outputs.source_version }}
       image_archive_key: ${{ secrets.ARTIFACT_KEY }}
-      build_args: |
-        FOUNDRY_PASSWORD=${{ secrets.FOUNDRY_PASSWORD }}
-        FOUNDRY_USERNAME=${{ secrets.FOUNDRY_USERNAME }}
-        VERSION=${{ needs.metadata.outputs.source_version }}
 
 # Since we need to pass the foundryvtt.com credentials to the tests, we can't
 # use the standard reusable test workflow.  Instead, we'll use a modified
@@ -196,14 +198,14 @@ jobs:
     uses: felddy/reusable-workflows/.github/workflows/docker-build-image.yml@develop
     with:
       artifact_name: ${{ needs.config.outputs.image_archive_artifact_name }}
+      build_arg_1_name: VERSION
       cache_from_scopes: ${{ matrix.platform }}
       cache_to_scope: ${{ matrix.platform }}
       image_labels: ${{ needs.metadata.outputs.image_labels }}
       image_archive_name_stem: ${{ matrix.platform }}
       platforms: ${{ matrix.platform }}
     secrets:
-      build_args: |
-        VERSION=${{ needs.metadata.outputs.source_version }}
+      build_arg_1_value: ${{ needs.metadata.outputs.source_version }}
 
   generate-sboms:
     name: "Bill of Materials"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR converts the build args to the new format.
Fixes typo preventing publication of descriptions to Docker hub on release.

Closes #694 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Prevents unreacted credentials from being logged by called workflows.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested in separate branches. 

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

