### PR TITLE
Expose the foundry port setting via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The following ports are exposed by this container:
 
 | Port | Purpose        |
 |------|----------------|
-| `30000` | Foundry Virtual Tabletop server web interface |
+| `30000` | Foundry Virtual Tabletop server web interface (may be changed by setting `FOUNDRY_PORT` environment variable). |
 
 ## Environment variables ##
 
@@ -275,6 +275,7 @@ secrets](#using-secrets) instead of environment variables.
 | `FOUNDRY_COMPRESS_WEBSOCKET` | Set to `true` to enable compression of data sent from the server to the client via websocket. This is recommended for network performance. | `true` |
 | `FOUNDRY_DEMO_CONFIG` | Demo mode allows you to configure a world which will be automatically launched and reset at a frequency of your choosing.  When the world is reset, it is deactivated.  The source data for the world is restored to its original state using a provided `.zip` file, and the next reset is automatically scheduled.  See: [Configuring demo mode](https://foundryvtt.com/article/configuration/#command-line). |  |
 | `FOUNDRY_GID` | `gid` the daemon will be run under. | `foundry` |
+| `FOUNDRY_PORT` | The port that will be used by foundry. | `30000` |
 | `FOUNDRY_HOSTNAME` | A custom hostname to use in place of the host machine's public IP address when displaying the address of the game session. This allows for reverse proxies or DNS servers to modify the public address. | `null` |
 | `FOUNDRY_HOT_RELOAD` | Set to `true` to allow packages to hot-reload certain assets, such as CSS, HTML, and localization files without a full refresh. This setting is only recommended for developers. | `false` |
 | `FOUNDRY_IP_DISCOVERY` | Allow the Foundry server to discover and report the accessibility of the host machine's public IP address and port.  Setting this to `false` may reduce server startup time in instances where this discovery would timeout. | `true` |

--- a/src/set_options.ts
+++ b/src/set_options.ts
@@ -49,7 +49,7 @@ let options: object = {
   language: process.env.FOUNDRY_LANGUAGE || LANGUAGE,
   localHostname: process.env.FOUNDRY_LOCAL_HOSTNAME || null,
   passwordSalt: process.env.FOUNDRY_PASSWORD_SALT || null,
-  port: FOUNDRY_PORT,
+  port: process.env.FOUNDRY_PORT || FOUNDRY_PORT,
   protocol: process.env.FOUNDRY_PROTOCOL || null,
   proxyPort: clampEnv(
     process.env.FOUNDRY_PROXY_PORT,


### PR DESCRIPTION

## 🗣 Description ##

This PR adds the environment variable `FOUNDRY_PORT` that can be used to change the port set for foundry in the options.json file.

## 💭 Motivation and context ##

To be able to run several instances of foundry on the same host it is necessary to adjust the port foundry is running on (please correct me if I'm somehow wrong here and there is some docker magic to make it work).
I have a few instances foundry set up in a docker-compose file, but when I start it up, I always get the following error message on the second instance to start up:
```
Error response from daemon: driver failed programming external connectivity on endpoint foundry-***-1 (e0af07952dea6876c73e03812bd694b7be857dd5d960d6d5e18be7a47300d1d5): Bind for 0.0.0.0:30000 failed: port is already allocated
```

## 🧪 Testing ##

No testing done yet, I hope I'll get to that later.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
