### PR TITLE
Feature:  Check installation file for correct type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ RUN addgroup --system --gid ${FOUNDRY_UID} foundry \
   && adduser --system --uid ${FOUNDRY_UID} --ingroup foundry foundry \
   && apk --update --no-cache add \
   curl \
+  file \
   jq \
   sed \
   su-exec \

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -157,8 +157,31 @@ if [ $install_required = true ]; then
 
   if [ -f "${release_filename}" ]; then
     log "Installing Foundry Virtual Tabletop ${FOUNDRY_VERSION}"
-    unzip -q "${release_filename}" 'resources/*'
-    log_debug "Installation completed."
+
+    # Check the mime-type of the file
+    log_debug "Checking mime-type of release file."
+    mime_type=$(file --mime-type --brief "${release_filename}")
+    log_debug "Found mime-type: ${mime_type}"
+
+    # Check if the file is a zip archive
+    if [ "${mime_type}" = "application/zip" ]; then
+      log_debug "Extracting release file."
+      unzip -q "${release_filename}" 'resources/*'
+      log_debug "Installation completed."
+    elif [ "${mime_type}" = "application/vnd.microsoft.portable-executable" ]; then
+      log_error "The release file appears to be a Windows executable (.exe)."
+      log_error "Please provide the 'Linux/NodeJS' version of the release or URL."
+      exit 1
+    elif [ "${mime_type}" = "application/zlib" ]; then
+      log_error "The release file appears to be a Mac disk image (.dmg)."
+      log_error "Please provide the 'Linux/NodeJS' version of the release or URL."
+      exit 1
+    else
+      log_error "The release file does not contain the expected zip data."
+      log_error "Found: ${mime_type} instead of application/zip"
+      log_error "Make sure you provided the 'Linux/NodeJS' version of the release or URL."
+      exit 1
+    fi
   else
     log_error "Unable to install Foundry Virtual Tabletop!"
     log_error "Either set FOUNDRY_RELEASE_URL."


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR adds a feature that checks to see if the user provided the correct FoundryVTT
installation archive or URL.  If it doesn't find the correct version it emits a help set of error
messages to explain the situation.

The log messages generated by this feature:
```console
Entrypoint | 2023-08-28 19:17:27 | [info] Installing Foundry Virtual Tabletop 11.308
Entrypoint | 2023-08-28 19:17:27 | [debug] Checking mime-type of release file.
Entrypoint | 2023-08-28 19:17:27 | [debug] Found mime-type: application/vnd.microsoft.portable-executable
Entrypoint | 2023-08-28 19:17:27 | [error] The release file appears to be a Windows executable (.exe).
Entrypoint | 2023-08-28 19:17:27 | [error] Please provide the 'Linux/NodeJS' version of the release or URL.
foundryvtt-mine-foundry-1 exited with code 1
```

Which is an improvement of the old logging:
```console
Entrypoint | 2022-12-14 22:44:06 | [info] Installing Foundry Virtual Tabletop 10.291
unzip: short read
```

Closes #282 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Requested in:
- #282 

This is a reoccurring issue for users that attempt to provide their own timed URL generated on [foundryvtt.com](https://foundryvtt.com).  The UI has been known to cause confusion as it defaults to downloading a windows `.exe`.  See screenshots below.  Multiple duplicate issues have been open about this behavior over the years.  Hopefully this will help users diagnose the issue more quickly. 

See:
- #113 
- #539 
- #724 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

It has been tested locally on my development box, and in continuous integration.

## 📷 Screenshots ##

![image](https://github.com/felddy/foundryvtt-docker/assets/3229435/9a98dbf4-710d-4bd1-b464-8f94f2a3a91c)

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

