### PR TITLE
Properly utilize exec in helper scripts

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -296,8 +296,8 @@ export CONTAINER_PRESERVE_CONFIG FOUNDRY_ADMIN_KEY FOUNDRY_AWS_CONFIG \
   FOUNDRY_PASSWORD_SALT FOUNDRY_PROTOCOL FOUNDRY_PROXY_PORT FOUNDRY_PROXY_SSL \
   FOUNDRY_ROUTE_PREFIX FOUNDRY_SSL_CERT FOUNDRY_SSL_KEY FOUNDRY_TELEMETRY FOUNDRY_UPNP \
   FOUNDRY_UPNP_LEASE_DURATION FOUNDRY_WORLD
-su-exec "${FOUNDRY_UID}:${FOUNDRY_GID}" ./launcher.sh "$@" \
-  || log_error "Launcher exited with error code: $?"
+exec su-exec "${FOUNDRY_UID}:${FOUNDRY_GID}" ./launcher.sh "$@" \
+  || log_error "Exec failed with error code: $?"
 
 # If the container requested a new S3 URL but disabled the cache
 # we are going to sleep forever to prevent a download loop.

--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -75,8 +75,8 @@ while IFS='=' read -rd '' ENV_VAR_NAME ENV_VAR_VALUE; do
   done
 done < <(env -0)
 
-# Spawn node with clean environment to prevent credential leaks
+# Exec node with clean environment to prevent credential leaks
 log "Starting Foundry Virtual Tabletop."
 # We want ENV_VAR_CARRY_LIST to word split
 # shellcheck disable=SC2086
-env -i $ENV_VAR_CARRY_LIST node "$@" || log_error "Node process exited with code $?"
+exec env -i $ENV_VAR_CARRY_LIST node "$@" || log_error "Exec failed with code $?"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR modifies the way that `launcher.sh` and the ultimate `node` processes are created.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

The `enterypoint.sh` script will now call `exec su-exec` instead of just `su-exec` when
starting the `launcher.sh`.  I had wrongly assumed that `su-exec` was also `exec`ing. 

Similarly `launcher.sh` will now use `exec env`... instead of `env` to start `node`.  

The motivation is to get the `node` process as PID 1 in the container, thus simplifying signal handling.

I went this route instead of implementing traps or using an init process as it was my original design goal to have a simple, single-process container.  

Closes #813 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested locally on my development box.  I was able to verify that the process list is collapsed as designed.

Before:
```console
➤ docker compose exec -it foundry ps
PID   USER     TIME  COMMAND
    1 root      0:00 {entrypoint.sh} /bin/sh ./entrypoint.sh resources/app/main.mjs --port=30000 --headless --noupdate --dataPath=/data
  112 501       0:00 {launcher.sh} /bin/sh ./launcher.sh resources/app/main.mjs --port=30000 --headless --noupdate --dataPath=/data
  142 501       0:01 node resources/app/main.mjs --port=30000 --headless --noupdate --dataPath=/data
  163 root      0:00 ps
```

After:
```console
➤ docker compose exec -it foundry ps
PID   USER     TIME  COMMAND
    1 501       0:01 node resources/app/main.mjs --port=30000 --headless --noupdate --dataPath=/data
  329 root      0:00 ps
```

Also tested in CI. 

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
