### PR TITLE
Refactor exec of child process to trap, spawn, signal, and wait pattern

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -34,6 +34,20 @@ if [ "$(id -u)" = 0 ]; then
   log_debug "Timezone set to: ${TIMEZONE:-UTC}"
 fi
 
+# Setup the SIGTERM handler
+# shellcheck disable=SC2317
+# SC2317 - shellcheck does not understand reachability via traps
+handle_sigterm() {
+  log_warn "TERM signal received.  Shutting down server."
+  # Only attempt to terminate if the child process is still running
+  if kill -0 "$child_pid" 2> /dev/null; then
+    log_debug "Sending TERM signal to child pid: ${child_pid}"
+    kill -TERM "$child_pid" 2> /dev/null
+  else
+    log_warn "Child pid: ${child_pid} exited before we could sent TERM signal."
+  fi
+}
+
 log "Starting felddy/foundryvtt container v${image_version}"
 log_debug "CONTAINER_VERBOSE set.  Debug logging enabled."
 log_debug "Running as: $(id)"
@@ -296,8 +310,21 @@ export CONTAINER_PRESERVE_CONFIG FOUNDRY_ADMIN_KEY FOUNDRY_AWS_CONFIG \
   FOUNDRY_PASSWORD_SALT FOUNDRY_PROTOCOL FOUNDRY_PROXY_PORT FOUNDRY_PROXY_SSL \
   FOUNDRY_ROUTE_PREFIX FOUNDRY_SSL_CERT FOUNDRY_SSL_KEY FOUNDRY_TELEMETRY FOUNDRY_UPNP \
   FOUNDRY_UPNP_LEASE_DURATION FOUNDRY_WORLD
-exec su-exec "${FOUNDRY_UID}:${FOUNDRY_GID}" ./launcher.sh "$@" \
-  || log_error "Exec failed with error code: $?"
+# set the TERM signal handler
+trap handle_sigterm TERM
+su-exec "${FOUNDRY_UID}:${FOUNDRY_GID}" ./launcher.sh "$@" &
+child_pid=$!
+log_debug "Waiting for child pid: ${child_pid} to exit."
+wait "$child_pid"
+exit_code=$?
+# clear the TERM signal handler
+trap - TERM
+log_debug "Child process exited with code: ${exit_code}."
+
+# Check if the child exited with an error code
+if [ $exit_code -ne 0 ]; then
+  log_error "Child process failed with error code: $exit_code"
+fi
 
 # If the container requested a new S3 URL but disabled the cache
 # we are going to sleep forever to prevent a download loop.

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -333,7 +333,7 @@ if [[ "${requested_s3_url}" == "true" && "${CONTAINER_CACHE:-}" == "" ]]; then
   log_warn "This configuration could lead to a restart loop putting excessive load on the release server."
   log_warn "Please re-enable the CONTAINER_CACHE to allow the container to safely exit."
   log_warn "Sleeping..."
-  while true; do sleep 60; done
+  while true; do sleep 4; done
 fi
 
 exit 0


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR changes the way the child processes are managed by the entrypoint script.
Specifically it backs out some of the changes from #822 

Instead of `exec`ing the `launcher.sh` it will now be spawned into the background and waited on.
`TERM` signals will be trapped and forwarded to the child while waiting.
This allows the DDOS bucket protection code to execute if needed. 

It also reduces the sleep interval in the infinite loop to allow container shutdown to be more responsive
when sleeping.

See:
- #822
- #307 

Closes #813 


## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

I realized that the DDOS protection in the entrypoint would not execute after the `exec` call.
I expect that there are deployments that have disabled caching that may still need this mitigation.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I tested locally that the signals are properly handled by the child processes.
I disable the `CONTAINER_CACHE` and killed the `node` process to verify that the entrypoint would
execute the infinite sleep.
Also CI.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
