### PR TITLE
Clean up CONTAINER_CACHE

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -148,6 +148,14 @@ if [ $install_required = true ]; then
     log_warn "CONTAINER_CACHE has been unset.  Release caching is disabled."
   fi
 
+  # Clears older Foundry versions that exist in CONTAINER_CACHE.
+  if [[ -z "$(find "${CONTAINER_CACHE}" -type f -not -name "*${FOUNDRY_VERSION}*" 2> /dev/null)" ]]; then
+    log "CONTAINER_CACHE does not have older versions."
+  else
+    log "CONTAINER_CACHE is not empty. Proceeding to clear the folder of older versions."
+    find "${CONTAINER_CACHE}" -type f -not -name "*${FOUNDRY_VERSION}*" -print0 | xargs -0 rm --
+  fi
+  
   set +o nounset
   downloading_filename="${CONTAINER_CACHE%%+(/)}${CONTAINER_CACHE:+/}downloading.zip"
   release_filename="${CONTAINER_CACHE%%+(/)}${CONTAINER_CACHE:+/}foundryvtt-${FOUNDRY_VERSION}.zip"


### PR DESCRIPTION
## 🗣 Description ##

Clean up older Foundry versions saved in CONTAINER_CACHE

## 💭 Motivation and context ##

Save space on host machine and still allow the latest version to be cached.

## 🧪 Testing ##

Built the image and deployed to [DockerHub](https://hub.docker.com/repository/docker/madereddy/foundryvtt/general)

Deployed via Docker Compose

First deployment of Image:
![image](https://github.com/felddy/foundryvtt-docker/assets/49539048/dd57edb8-eff0-4f16-813e-ffbc1ef07ebd)

```
Entrypoint | 2023-11-15 19:44:34 | [[32minfo[0m] CONTAINER_CACHE is not empty. Proceeding to clear the folder of older versions.
```
Cleaned the container and redeployed using Docker Compose

![image](https://github.com/felddy/foundryvtt-docker/assets/49539048/0e4629fa-b646-435e-8978-04058add96b8)

```
Entrypoint | 2023-11-15 19:50:17 | [[32minfo[0m] CONTAINER_CACHE does not have older versions.
```

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [ ] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Add a tag or create a release.
