### PR TITLE
Delete invalid FoundryVTT distribution files from the cache when detected

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -182,21 +182,21 @@ if [ $install_required = true ]; then
       log_debug "Extracting release file."
       unzip -q "${release_filename}" 'resources/*'
       log_debug "Installation completed."
-    elif [ "${mime_type}" = "application/vnd.microsoft.portable-executable" ]; then
-      log_error "The release file appears to be a Windows executable (.exe)."
+    else # The user provided the wrong file.
+      if [ "${mime_type}" = "application/vnd.microsoft.portable-executable" ]; then
+        log_error "The release file appears to be a Windows executable (.exe)."
+      elif [ "${mime_type}" = "application/zlib" ]; then
+        log_error "The release file appears to be a Mac disk image (.dmg)."
+      else
+        log_error "The release file does not contain the expected zip data."
+        log_error "Found: ${mime_type} instead of application/zip"
+      fi
       log_error "Please provide the 'Linux/NodeJS' version of the release or URL."
+      log_warn "Deleting invalid release file from cache."
+      rm "${release_filename}"
       exit 1
-    elif [ "${mime_type}" = "application/zlib" ]; then
-      log_error "The release file appears to be a Mac disk image (.dmg)."
-      log_error "Please provide the 'Linux/NodeJS' version of the release or URL."
-      exit 1
-    else
-      log_error "The release file does not contain the expected zip data."
-      log_error "Found: ${mime_type} instead of application/zip"
-      log_error "Make sure you provided the 'Linux/NodeJS' version of the release or URL."
-      exit 1
-    fi
-  else
+    fi # mime_type is zip
+  else # release_filename does not exist
     log_error "Unable to install Foundry Virtual Tabletop!"
     log_error "Either set FOUNDRY_RELEASE_URL."
     log_error "Or set FOUNDRY_USERNAME and FOUNDRY_PASSWORD."


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

When an invalid file distribution file is detected we now delete it from the cache.   Previously it would remain in the cache
and block additional attempts to download the corrected version.

See:
- #843

Closes #843

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Do to the defaults of foundryvtt.com's download page, and the excitement of users it is not uncommon for
people to supply the wrong pre-signed S3 URL.  The default operating system in the web interface is `Windows` and many users just click the generate or download button without selecting `Linux/NodeJS`.   Examples of this confusion:
- #113
- #282
- #283
- #539
- #724
- #806 

Earlier this year I tried to mitigate this class of problems with a new feature that checks the mime type of the downloaded file:
- #767 

While this does notify the user that the file type is incorrect, it did not remove the file.  I've been hesitant to delete data from a user's volume, but that ship has sailed with the addition of the recent cache management feature:
- #841 

Invalid files will now be deleted from the `CONTAINER_CACHE` directory when detected.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I started the container with the `FOUNDRY_RELEASE_URL` set to a URL for `Windows`.  This is the log of that run:
```console
...
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:40:26 | [info] No Foundry Virtual Tabletop installation detected.
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:40:26 | [info] Using FOUNDRY_RELEASE_URL to download release.
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:40:26 | [info] Using CONTAINER_CACHE: /data/container_cache_843
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:40:26 | [info] Downloading Foundry Virtual Tabletop release.
...
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:40:42 | [info] Installing Foundry Virtual Tabletop 11.315
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:40:42 | [debug] Checking mime-type of release file.
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:40:42 | [debug] Found mime-type: application/vnd.microsoft.portable-executable
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:40:42 | [error] The release file appears to be a Windows executable (.exe).
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:40:42 | [error] Please provide the 'Linux/NodeJS' version of the release or URL.
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:40:42 | [warn] Deleting invalid release file from cache.
foundryvtt-mine-foundry-1 exited with code 1
```

A subsequent run was then made with the same `CONTAINER_CACHE` and the correct URL for `Linux/NodeJS`:
```console
...
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:41:36 | [info] No Foundry Virtual Tabletop installation detected.
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:41:36 | [info] Using FOUNDRY_RELEASE_URL to download release.
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:41:36 | [info] Using CONTAINER_CACHE: /data/container_cache_843
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:41:36 | [info] Downloading Foundry Virtual Tabletop release.
...
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:41:53 | [info] Installing Foundry Virtual Tabletop 11.315
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:41:53 | [debug] Checking mime-type of release file.
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:41:53 | [debug] Found mime-type: application/zip
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:41:53 | [debug] Extracting release file.
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:41:54 | [debug] Installation completed.
foundryvtt-mine-foundry-1  | Entrypoint | 2023-11-20 10:41:54 | [info] Preserving release archive file in cache.
...
```

Also testing in continuous integration.


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
