### PR TITLE
Remove `lazy-fixture-pytest` library for upgrade to `pytest` `v8.0.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
             "coveralls == 3.3.1",
             "docker == 7.0.0",
             "pre-commit == 3.6.0",
-            "pytest == 7.4.4",
+            "pytest == 8.0.0",
             "pytest-cov == 4.1.0",
             "pytest-lazy-fixture == 0.6.3",
         ]

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ setup(
             "pre-commit == 3.6.0",
             "pytest == 8.0.0",
             "pytest-cov == 4.1.0",
-            "pytest-lazy-fixture == 0.6.3",
         ]
     },
 )

--- a/tests/container_test.py
+++ b/tests/container_test.py
@@ -15,10 +15,13 @@ READY_MESSAGE = "Server started and listening on port"
 
 @pytest.mark.parametrize(
     "container",
-    [pytest.lazy_fixture("main_container"), pytest.lazy_fixture("version_container")],
+    ["main_container", "version_container"],
 )
-def test_container_running(container):
+def test_container_running(container, request):
     """Test that the container has started."""
+    # Lazy fixture evaluation
+    container = request.getfixturevalue(container)
+
     # Wait until the container is running or timeout.
     for _ in range(10):
         container.reload()


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Removes the `pytest-lazy-fixture` library as it is now unmaintained.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

`pytest v8.0.0` now fails with `pytest-lazy-fixture`.  The work-around is trivial.
This functionality [may get implemented in pytest in the future](https://github.com/TvoroG/pytest-lazy-fixture/issues/63), so we should keep an eye out for that.

See:
- https://github.com/TvoroG/pytest-lazy-fixture/issues/65
- https://github.com/felddy/foundryvtt-docker/pull/886#issuecomment-1919558263

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested locally and in CI. 


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

