### PR TITLE
Add hotfix for issue #697 - v11 database glibc workaround

### DIFF
--- a/patches/hotfix_issue_697.sh
+++ b/patches/hotfix_issue_697.sh
@@ -1,0 +1,20 @@
+#!/bin/ash
+# shellcheck shell=dash
+
+# Issue 697 Fix
+# =====================
+# V11 Database glibc Workaround
+# In upgrading to the new database engine for v11, some devices may experience
+# an error related to an invalid version of glibc. This most notably affects ARM
+# architecture devices, including some models of Raspberry Pi.
+
+PATCH_DOC_URL="https://github.com/felddy/foundryvtt-docker/issues/697"
+PATCH_NAME="Fix for issue #697 - v11 database glibc workaround"
+
+log "Applying \"${PATCH_NAME}\""
+log "See: ${PATCH_DOC_URL}"
+
+apk add g++ make python3
+cd resources/app || exit
+npm install classic-level --build-from-source
+cd - || exit


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR add this fix developed in #697 to a script in the patches directory.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

This will make it easier to apply the patch using only the environment variable config instead of creating a local patches directory.

For example:

```yaml
---
version: "3.8"

services:
  foundry:
    image: felddy/foundryvtt:release
    hostname: my_foundry_host
    volumes:
      - type: bind
        source: <your_data_dir>
        target: /data
    environment:
      - CONTAINER_PATCH_URLS=
        https://raw.githubusercontent.com/felddy/foundryvtt-docker/develop/patches/hotfix_issue_697.sh
      - FOUNDRY_PASSWORD=<your_password>
      - FOUNDRY_USERNAME=<your_username>
      - FOUNDRY_ADMIN_KEY=atropos
    ports:
      - target: 30000
        published: 30000
        protocol: tcp
```

See:
- #697 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

Tested on local instances.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

