### PR TITLE
Add groups to Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
       - "bot :robot:"
       - "dependencies :game_die:"
       - "docker :whale:"
+    groups:
+      docker-all:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -24,6 +29,11 @@ updates:
       - "bot :robot:"
       - "dependencies :game_die:"
       - "github-actions :octocat:"
+    groups:
+      github-actions-all:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -33,6 +43,11 @@ updates:
       - "bot :robot:"
       - "dependencies :game_die:"
       - "javascript :coffee:"
+    groups:
+      npm-all:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -42,3 +57,8 @@ updates:
       - "bot :robot:"
       - "dependencies :game_die:"
       - "python :snake:"
+    groups:
+      pip-all:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR adds groups to each Dependabot ecosystem.
The result will the creation of fewer PRs for version updates. 
Each PR can now contain multiple changes per ecosystem.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

It gets a bit overwhelming at times to have a ton of version updates opened by dependabot.
Sometimes there is no resolvable way to test dependent version changes.  This happened recently
with the GitHub Actions artifact upload and download actions.  This should help in those situations.

This should reduce the number of times CI will get rate limited due to chained Dependabot rebases,
reducing costs for all involved. 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

It worked in reusable-workflows. 
🤞 

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

