### PR TITLE
Add redaction regex for Cloudflare pre-signed URLs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,10 @@ from .utils import RedactedPrinter
 
 MAIN_SERVICE_NAME = "foundry"
 REDACTION_REGEXES = [
+    # AWS S3 pre-signed URL
     re.compile(r"AWSAccessKeyId=(.*?)&Signature=(.*?)&"),
+    # Cloudflare R2 pre-signed URL
+    re.compile(r"\?verify=([0-9]+-[a-zA-Z0-9%]+)"),
 ]
 VERSION_FILE = "src/_version.py"
 VERSION_SERVICE_NAME = f"{MAIN_SERVICE_NAME}-version"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR enables the redaction of Cloudflare R2 pre-signed URLs from testing logs.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

- FoundryVTT now uses Cloudflare R2 to host its distributions.
- The previous redaction regular expression for AWS S3 does not match R2.
- We want to continue to protect pre-signed URLs in CI from leaking.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested locally and in CI.  

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
