### PR TITLE
Add clarification to FOUNDRY_WORLD var in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ secrets](#using-secrets) instead of environment variables.
 | `FOUNDRY_UPNP` | Allow Universal Plug and Play to automatically request port forwarding for the Foundry server port to your local network address. | `false` |
 | `FOUNDRY_UPNP_LEASE_DURATION` | Sets the Universal Plug and Play lease duration, allowing for the possibility of permanent leases for routers which do not support temporary leases.  To define an indefinite lease duration set the value to `0`. | `null` |
 | `FOUNDRY_VERSION` | Version of Foundry Virtual Tabletop to install. | `12.331` |
-| `FOUNDRY_WORLD` | The world to startup at system start. | `null` |
+| `FOUNDRY_WORLD` | The world to startup at system start. Use the world's folder name, not the "pretty" name.  | `null` |
 | `TIMEZONE`     | Container [TZ database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List) | `UTC` |
 
 ### Node.js variables ###


### PR DESCRIPTION

## 🗣 Description ##

Add a brief explanation in the readme file as to how to use this variable.

## 💭 Motivation and context ##

I could not choose a default world via the docker-compose file, until a discord user mentioned that `FOUNDRY_WORLD` must be set as the folder name and not the pretty name.   
I believe this fix will make this easier for future users to understand.


## 🧪 Testing ##

I verified that my branch displays the value as expected

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*

- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
