### PR TITLE
Cache fallback on network failure

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -157,6 +157,8 @@ END_OF_LINE
 
   if [[ "${presigned_url:-}" ]]; then
     log "Downloading Foundry Virtual Tabletop release."
+    # Temporarily disable errexit for the curl command to capture its exit status
+    set +e
     # Download release if newer than cached version.
     # Filter out warnings about bad date formats if the file is missing.
     curl ${CONTAINER_VERBOSE+--verbose} --fail --location \
@@ -165,10 +167,25 @@ END_OF_LINE
       --output "${downloading_filename}" "${presigned_url}" 2>&1 \
       | tr "\r" "\n" \
       | sed --unbuffered '/^Warning: .* date/d'
+    curl_exit_code=$?
+    set -e
 
-    # Rename the download now that it is completed.
-    # If we had a cache hit, the file is already renamed.
-    mv "${downloading_filename}" "${release_filename}" > /dev/null 2>&1 || true
+    if [ ${curl_exit_code} -ne 0 ]; then
+      log_warn "Download from presigned URL failed with exit code ${curl_exit_code}."
+      # Remove any partially downloaded file
+      [ -f "${downloading_filename}" ] && rm -f "${downloading_filename}"
+
+      if [ -f "${release_filename}" ]; then
+        log "Falling back to existing cached release file: ${release_filename}"
+      else
+        log_error "No valid cached release file found. Unable to proceed with installation."
+        exit 1
+      fi
+    else
+      # Download succeeded so rename the file to the final name.
+      # If we had a cache hit, the file is already renamed.
+      mv "${downloading_filename}" "${release_filename}" > /dev/null 2>&1 || true
+    fi
   fi
 
   if [ -f "${release_filename}" ]; then

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -114,16 +114,21 @@ if [ $install_required = true ]; then
     log "Using FOUNDRY_USERNAME and FOUNDRY_PASSWORD to authenticate."
     # If credentials are provided attempt authentication.
     # The resulting cookiejar is used to get a release URL or license.
-    # CONTAINER_VERBOSE default value should not be quoted.
-    # shellcheck disable=SC2086
+
+    # Temporarily disable errexit to capture failure from authenticate.js
+    set +e
     ./authenticate.js ${CONTAINER_VERBOSE+--log-level=debug} \
       --user-agent="${node_user_agent}" \
       "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${cookiejar_file}"
-    if [[ ! "${presigned_url:-}" ]]; then
+    auth_exit_code=$?
+    set -e
+
+    if [ ${auth_exit_code} -ne 0 ]; then
+      log_warn "Authentication failed with exit code ${auth_exit_code}."
+      rm -f "${cookiejar_file}"
+    elif [[ ! "${presigned_url:-}" ]]; then
       # If the presigned_url wasn't set by FOUNDRY_RELEASE_URL generate one now.
-      log "Using authenticated credentials to download release."
-      # CONTAINER_VERBOSE default value should not be quoted.
-      # shellcheck disable=SC2086
+      log "Using authenticated credentials to fetch release URL."
       presigned_url=$(./get_release_url.js ${CONTAINER_VERBOSE+--log-level=debug} \
         ${CONTAINER_URL_FETCH_RETRY+--retry=${CONTAINER_URL_FETCH_RETRY}} \
         --user-agent="${node_user_agent}" \


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

The container will alway try to see if a newer (by timestamp) distribution for the current version of FoundryVTT exists.  This is because newer distributions have been published in the past without bumping the version of FoundryVTT.  

This PR will allow the container to fail back to the cache when there is a network failure while trying to fetch the latest release of FoundryVTT, or check the timestamp in the r2 bucket. 

Some cases where this can happen are:
- the `FOUNDRY_RELEASE_URL` is set to an expired timed URL.
- the `FOUNDRY_USERNAME` or `FOUNDRY_PASSWORD` are invalid.
- `foundryvtt.com` is down.
- `r2.foundryvtt.com` is down. 

Closes #212 
Closes #1055

See:
- #212 
- #1055 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

It was annoying that a network failure didn't result in automatically failing back to the cache.  Users had to
manually disable their credentials, or remove the timed URL.  

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested locally and in CI.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
