### PR TITLE
Check /data volume permissions at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ secrets](#using-secrets) instead of environment variables.
 | `FOUNDRY_UPNP` | Allow Universal Plug and Play to automatically request port forwarding for the Foundry server port to your local network address. | `false` |
 | `FOUNDRY_UPNP_LEASE_DURATION` | Sets the Universal Plug and Play lease duration, allowing for the possibility of permanent leases for routers which do not support temporary leases.  To define an indefinite lease duration set the value to `0`. | `null` |
 | `FOUNDRY_VERSION` | Version of Foundry Virtual Tabletop to install. | `13.340` |
-| `FOUNDRY_WORLD` | The world to startup at system start. | `null` |
+| `FOUNDRY_WORLD` | The directory name of the world to launch at system start. | `null` |
 | `TZ`     | Container [TZ database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List) | `UTC` |
 
 ### Node.js variables ###

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -4,7 +4,8 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-CONFIG_DIR="/data/Config"
+DATA_DIR="/data"
+CONFIG_DIR="${DATA_DIR}/config"
 DEPRECATED_ENVS="CONTAINER_PRESERVE_OWNER FOUNDRY_UID FOUNDRY_GID TIMEZONE"
 LICENSE_FILE="${CONFIG_DIR}/license.json"
 # setup logging
@@ -139,7 +140,7 @@ if [ $install_required = true ]; then
 
   # If CONTAINER_CACHE is null, set it to a default.
   # If it set to an empty string, disable the caching.
-  CONTAINER_CACHE="${CONTAINER_CACHE-/data/container_cache}"
+  CONTAINER_CACHE="${CONTAINER_CACHE-${DATA_DIR}/container_cache}"
 
   if [[ "${CONTAINER_CACHE:-}" ]]; then
     log "Using CONTAINER_CACHE: ${CONTAINER_CACHE}"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -48,6 +48,41 @@ log "Starting felddy/foundryvtt container v${image_version}"
 log_debug "CONTAINER_VERBOSE set.  Debug logging enabled."
 log_debug "Running as: $(id)"
 log_debug "Environment:\n$(env | sort | sed -E 's/(.*PASSWORD|KEY.*)=.*/\1=[REDACTED]/g')"
+log_debug "Data directory: ${DATA_DIR}"
+
+# Show the mount details for the data directory
+mount_info=$(findmnt -n -o SOURCE,FSTYPE,OPTIONS --target "${DATA_DIR}")
+log_debug "Mount info for ${DATA_DIR}: ${mount_info}"
+
+# Test volume permissions
+permissions_test_file="${DATA_DIR}/.container-permissions-test.txt"
+permission_test_failed=0
+log_debug "Testing permissions on ${permissions_test_file}"
+if ! touch "${permissions_test_file}" 2> /dev/null; then
+  log_error "Volume write test failed."
+  permission_test_failed=1
+else
+  log_debug "Volume write test succeeded."
+fi
+if ! cat "${permissions_test_file}" > /dev/null 2>&1; then
+  log_error "Volume read test failed."
+  permission_test_failed=1
+else
+  log_debug "Volume read test succeeded."
+fi
+if ! rm -f "${permissions_test_file}" 2> /dev/null; then
+  log_error "Volume delete test failed."
+  permission_test_failed=1
+else
+  log_debug "Volume delete test succeeded."
+fi
+if [ "${permission_test_failed}" -ne 0 ]; then
+  log_error "Aborting due to insufficient permissions on ${DATA_DIR}"
+  log_error "Container running as uid:gid: $(id -u):$(id -g)"
+  log_error "For more information see the discussion at: https://github.com/felddy/foundryvtt-docker/discussions/1197"
+  exit 1
+fi
+log_debug "All permissions tests succeeded."
 
 cookiejar_file="/tmp/cookiejar.json"
 license_min_length=24


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR adds checks early in the container startup to diagnose any permission issues.
It verifies that it can create, read, and delete files in the `/data` volume. 
If it cannot the container logs errors, and exits.

It will direct users to this discussion thread: 
- https://github.com/felddy/foundryvtt-docker/discussions/1197

Also incorporated a suggestion to improve the description of the `FOUNDRY_WORLD` environment variable:
- #1084 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

A bunch of changes were made in `v13.333.0` to improve the security and portability of the container.
One of the biggest changes was running as the default `node` user and group `1000:1000` instead of root at startup.
Previously the container would start as root, and then switch to 421:421 which was the `foundry` user in the container.

This change will cause permission errors if users don't realize what is going on.  The additional logging should help out.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
