### PR TITLE
Store healthcheck cookiejar in /tmp/

### DIFF
--- a/src/check_health.sh
+++ b/src/check_health.sh
@@ -12,6 +12,6 @@ else
   STATUS_URL="${protocol}://localhost:30000/api/status"
 fi
 
-/usr/bin/curl --cookie-jar healthcheck-cookiejar.txt \
-  --cookie healthcheck-cookiejar.txt --insecure --fail --silent \
+/usr/bin/curl --cookie-jar /tmp/healthcheck-cookiejar.txt \
+  --cookie /tmp/healthcheck-cookiejar.txt --insecure --fail --silent \
   "${STATUS_URL}" || exit 1


### PR DESCRIPTION
The home directory might not be writable by the user running the image, in which case the cookiejar is never written and Foundry creates a new session every 30 seconds, causing some log spam.

this fixes #1262