### PR TITLE
Follow redirects to download patch URLs

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -315,7 +315,7 @@ END_OF_LINE
     for url in ${CONTAINER_PATCH_URLS}; do
       log "Downloading patch from URL: $url"
       patch_file=$(mktemp -t patch_url.sh.XXXXXX)
-      curl ${CONTAINER_VERBOSE+--verbose} --silent \
+      curl ${CONTAINER_VERBOSE+--verbose} --silent --location \
         --user-agent "${curl_user_agent}" \
         --output "${patch_file}" "${url}"
       log_debug "Sourcing patch file: ${patch_file}"


### PR DESCRIPTION
## 🗣 Description ##

Download patches in CONTAINER_PATCH_URLS with `--location` flag to follow redirects.

## 💭 Motivation and context ##

For example github releases now don't directly link the files anymore, but instead redirect you first to a different url where the release asset is. This can be annoying and I'd prefer it to follow redirects when downloading patch files. The curl `--location` option does this and allows downloads from GH Releases to still work directly from the linked URL on the release page.

The foundryvtt zip is also already being downloaded with `--location`

## 🧪 Testing ##

Yes. Test it by providing a patch url that redirects and checking if the file still gets correctly downloaded.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
