### PR TITLE
Pin workflows and lock down runner egress

### DIFF
--- a/.github/workflows/_config.yml
+++ b/.github/workflows/_config.yml
@@ -41,6 +41,6 @@ permissions:
 jobs:
   csv-to-json:
     name: Convert CSV to JSON
-    uses: felddy/reusable-workflows/.github/workflows/csv-to-json.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/csv-to-json.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
     with:
       csv: ${{ inputs.platforms }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ defaults:
 jobs:
   diagnostics:
     name: Diagnostics
-    uses: felddy/reusable-workflows/.github/workflows/diagnostics.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/diagnostics.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
 
   config:
     name: Config
@@ -47,7 +47,7 @@ jobs:
     name: Metadata
     needs:
       - config
-    uses: felddy/reusable-workflows/.github/workflows/container-metadata.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/container-metadata.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
     with:
       image_name: ${{ needs.config.outputs.image_name }}
 
@@ -115,7 +115,7 @@ jobs:
     name: Lint
     needs:
       - config
-    uses: felddy/reusable-workflows/.github/workflows/common-lint.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/common-lint.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
 
   build-normal-container-for-testing:
     name: Build normal container for testing
@@ -123,7 +123,7 @@ jobs:
       - config
       - lint
       - metadata
-    uses: felddy/reusable-workflows/.github/workflows/container-build.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/container-build.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
     with:
       artifact_name: ${{ needs.config.outputs.image_artifact_name_stem }}-${{ needs.config.outputs.test_platform }}
       cache_from_scopes: ${{ needs.config.outputs.test_platform }}
@@ -140,7 +140,7 @@ jobs:
       - foundry-secrets
       - lint
       - metadata
-    uses: felddy/reusable-workflows/.github/workflows/container-build.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/container-build.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
     with:
       artifact_name: pre-installed-${{ needs.config.outputs.image_artifact_name_stem }}-${{ needs.config.outputs.test_platform }}
       build_secret_1_name: foundry_password
@@ -208,7 +208,7 @@ jobs:
         platform: ${{ fromJson(needs.config.outputs.platforms_json) }}
         exclude:
           - platform: ${{ needs.config.outputs.test_platform }}
-    uses: felddy/reusable-workflows/.github/workflows/container-build.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/container-build.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
     with:
       artifact_name: ${{ needs.config.outputs.image_artifact_name_stem }}-${{ matrix.platform }}
       cache_from_scopes: ${{ matrix.platform }}
@@ -227,7 +227,7 @@ jobs:
     strategy:
       matrix:
         platform: ${{ fromJson(needs.config.outputs.platforms_json) }}
-    uses: felddy/reusable-workflows/.github/workflows/container-sbom.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/container-sbom.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
     with:
       image_artifact_name: ${{ needs.config.outputs.image_artifact_name_stem }}-${{ matrix.platform }}
       sbom_artifact_name: ${{ needs.config.outputs.sbom_artifact_name_stem }}-${{ matrix.platform }}
@@ -241,7 +241,7 @@ jobs:
     if: github.event_name != 'pull_request'
     permissions:
       packages: write
-    uses: felddy/reusable-workflows/.github/workflows/container-publish-multiarch.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/container-publish-multiarch.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
     with:
       artifact_name_pattern: ${{ needs.config.outputs.image_artifact_name_stem }}-*
       image_tags: ${{ needs.metadata.outputs.image_tags }}
@@ -257,7 +257,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: felddy/reusable-workflows/.github/workflows/container-mirror.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/container-mirror.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
     with:
       image_name: ${{ needs.config.outputs.image_name }}
       image_tag_names: ${{ needs.metadata.outputs.image_tag_names }}
@@ -274,7 +274,7 @@ jobs:
       - docker-secrets
       - metadata
     if: github.event_name == 'release' && needs.metadata.outputs.latest == 'true'
-    uses: felddy/reusable-workflows/.github/workflows/dockerhub-description.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/dockerhub-description.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
     with:
       image_name: ${{ needs.config.outputs.image_name }}
     secrets:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   diagnostics:
     name: Run Diagnostics
-    uses: felddy/reusable-workflows/.github/workflows/diagnostics.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/diagnostics.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
   analyze:
     name: Analyze
     needs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -56,9 +56,14 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # tag=v2.13.3
         with:
-          # TODO: change to 'egress-policy: block' after couple of runs
-          egress-policy: audit
-
+          egress-policy: block
+          allowed-endpoints: >
+            *.github.com:443
+            *.githubapp.com:443
+            *.githubusercontent.com:443
+            files.pythonhosted.org:443
+            github.com:443
+            pypi.org:443
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # tag=v6.0.1
 

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -16,8 +16,9 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # tag=v2.13.3
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
       - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # tag=v10.1.1
         with:
           days-before-stale: 28

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -28,7 +28,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # tag=v2.13.3
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # tag=v6.0.1
       - name: Sync repository labels
         if: success()

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   diagnostics:
     name: Run Diagnostics
-    uses: felddy/reusable-workflows/.github/workflows/diagnostics.yml@v3
+    uses: felddy/reusable-workflows/.github/workflows/diagnostics.yml@64c533d92826ed147972fab05311f9ac35fdb48e # tag=v3.0.0
   labeler:
     needs:
       - diagnostics


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

This PR pins our reusable workflows by SHA and the remaining hardened runners from `audit` to `block` mode. 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Trying to improve the OpenSSF scorecard score. 
The stronger pinning is not a problematic now that dependabot will make PRs for reusable workflow releases.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

In CI only.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
