### PR TITLE
Fix container cache

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -139,8 +139,27 @@ else
   install_required=true
 fi
 
-# Install FoundryVTT if needed
+# Check to see if a download is required.
+download_required=false
 if [ $install_required = true ]; then
+  # If CONTAINER_CACHE is null, set it to a default.
+  # If it set to an empty string, disable the caching.
+  CONTAINER_CACHE="${CONTAINER_CACHE-${DATA_DIR}/container_cache}"
+
+  set +o nounset
+  downloading_filename="${CONTAINER_CACHE%%+(/)}${CONTAINER_CACHE:+/}downloading.zip"
+  release_filename="${CONTAINER_CACHE%%+(/)}${CONTAINER_CACHE:+/}foundryvtt-${FOUNDRY_VERSION}.zip"
+  set -o nounset
+
+  if [ -f "${release_filename}" ]; then
+    log "Existing download found in cache; installing from that."
+  else
+    download_required=true
+  fi
+fi
+  
+# Download FoundryVTT if needed
+if [ $download_required = true ]; then
   # Determine how we are going to get the release URL
   if [ "${FOUNDRY_RELEASE_URL:-}" ]; then
     log "Using FOUNDRY_RELEASE_URL to download release."
@@ -173,10 +192,6 @@ if [ $install_required = true ]; then
     fi
   fi
 
-  # If CONTAINER_CACHE is null, set it to a default.
-  # If it set to an empty string, disable the caching.
-  CONTAINER_CACHE="${CONTAINER_CACHE-${DATA_DIR}/container_cache}"
-
   if [[ "${CONTAINER_CACHE:-}" ]]; then
     log "Using CONTAINER_CACHE: ${CONTAINER_CACHE}"
     mkdir -p "${CONTAINER_CACHE}"
@@ -190,11 +205,6 @@ END_OF_LINE
   else
     log_warn "CONTAINER_CACHE has been unset.  Release caching is disabled."
   fi
-
-  set +o nounset
-  downloading_filename="${CONTAINER_CACHE%%+(/)}${CONTAINER_CACHE:+/}downloading.zip"
-  release_filename="${CONTAINER_CACHE%%+(/)}${CONTAINER_CACHE:+/}foundryvtt-${FOUNDRY_VERSION}.zip"
-  set -o nounset
 
   if [[ "${presigned_url:-}" ]]; then
     log "Downloading Foundry Virtual Tabletop release."
@@ -228,7 +238,10 @@ END_OF_LINE
       mv "${downloading_filename}" "${release_filename}" > /dev/null 2>&1 || true
     fi
   fi
+fi
 
+# Install FoundryVTT if needed
+if [ $install_required = true ]; then
   if [ -f "${release_filename}" ]; then
     log "Installing Foundry Virtual Tabletop ${FOUNDRY_VERSION}"
 


### PR DESCRIPTION
## 🗣 Description ##

We split the install phase to a download phase and an install phase,
performing the download only if we don't already have the correct file
in the container cache.

## 💭 Motivation and context ##

Without this, the container cache is never read from, only written to.

Closes #1333

## 🧪 Testing ##

This was manually tested by running the image multiple times with `--rm`.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
