### PR TITLE
Wait for in-progress download by other instance with same cache

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -201,8 +201,8 @@ END_OF_LINE
   fi
 
   set +o nounset
-  downloading_filename="${CONTAINER_CACHE%%+(/)}${CONTAINER_CACHE:+/}downloading.zip"
   release_filename="${CONTAINER_CACHE%%+(/)}${CONTAINER_CACHE:+/}foundryvtt-${FOUNDRY_VERSION}.zip"
+  downloading_filename="${release_filename}.part"
   set -o nounset
 
   if [[ ! -f "${release_filename"} ]]; then

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -182,37 +182,6 @@ fi
 
 # Install FoundryVTT if needed
 if [ $install_required = true ]; then
-  # Determine how we are going to get the release URL
-  if [ "${FOUNDRY_RELEASE_URL:-}" ]; then
-    log "Using FOUNDRY_RELEASE_URL to download release."
-    presigned_url="${FOUNDRY_RELEASE_URL}"
-  fi
-  if [[ "${FOUNDRY_USERNAME:-}" && "${FOUNDRY_PASSWORD:-}" ]]; then
-    log "Using FOUNDRY_USERNAME and FOUNDRY_PASSWORD to authenticate."
-    # If credentials are provided attempt authentication.
-    # The resulting cookiejar is used to get a release URL or license.
-
-    # Temporarily disable errexit to capture failure from authenticate.js
-    set +e
-    ./authenticate.js ${CONTAINER_VERBOSE+--log-level=debug} \
-      --user-agent="${node_user_agent}" \
-      "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${cookiejar_file}"
-    auth_exit_code=$?
-    set -e
-
-    if [ ${auth_exit_code} -ne 0 ]; then
-      log_warn "Authentication failed with exit code ${auth_exit_code}."
-      rm -f "${cookiejar_file}"
-    elif [[ ! "${presigned_url:-}" ]]; then
-      # If the presigned_url wasn't set by FOUNDRY_RELEASE_URL generate one now.
-      log "Using authenticated credentials to fetch release URL."
-      presigned_url=$(./get_release_url.js ${CONTAINER_VERBOSE+--log-level=debug} \
-        ${CONTAINER_URL_FETCH_RETRY+--retry=${CONTAINER_URL_FETCH_RETRY}} \
-        --user-agent="${node_user_agent}" \
-        "${cookiejar_file}" "${FOUNDRY_VERSION}")
-    fi
-  fi
-
   # If CONTAINER_CACHE is null, set it to a default.
   # If it is set to an empty string, disable the caching.
   CONTAINER_CACHE="${CONTAINER_CACHE-${DATA_DIR}/container_cache}"
@@ -235,6 +204,39 @@ END_OF_LINE
   downloading_filename="${CONTAINER_CACHE%%+(/)}${CONTAINER_CACHE:+/}downloading.zip"
   release_filename="${CONTAINER_CACHE%%+(/)}${CONTAINER_CACHE:+/}foundryvtt-${FOUNDRY_VERSION}.zip"
   set -o nounset
+
+  if [[ ! -f "${release_filename"} ]]; then
+    # Determine how we are going to get the release URL
+    if [ "${FOUNDRY_RELEASE_URL:-}" ]; then
+      log "Using FOUNDRY_RELEASE_URL to download release."
+      presigned_url="${FOUNDRY_RELEASE_URL}"
+    fi
+    if [[ "${FOUNDRY_USERNAME:-}" && "${FOUNDRY_PASSWORD:-}" ]]; then
+      log "Using FOUNDRY_USERNAME and FOUNDRY_PASSWORD to authenticate."
+      # If credentials are provided attempt authentication.
+      # The resulting cookiejar is used to get a release URL or license.
+
+      # Temporarily disable errexit to capture failure from authenticate.js
+      set +e
+      ./authenticate.js ${CONTAINER_VERBOSE+--log-level=debug} \
+        --user-agent="${node_user_agent}" \
+        "${FOUNDRY_USERNAME}" "${FOUNDRY_PASSWORD}" "${cookiejar_file}"
+      auth_exit_code=$?
+      set -e
+
+      if [ ${auth_exit_code} -ne 0 ]; then
+        log_warn "Authentication failed with exit code ${auth_exit_code}."
+        rm -f "${cookiejar_file}"
+      elif [[ ! "${presigned_url:-}" ]]; then
+        # If the presigned_url wasn't set by FOUNDRY_RELEASE_URL generate one now.
+        log "Using authenticated credentials to fetch release URL."
+        presigned_url=$(./get_release_url.js ${CONTAINER_VERBOSE+--log-level=debug} \
+          ${CONTAINER_URL_FETCH_RETRY+--retry=${CONTAINER_URL_FETCH_RETRY}} \
+          --user-agent="${node_user_agent}" \
+          "${cookiejar_file}" "${FOUNDRY_VERSION}")
+      fi
+    fi
+  fi
 
   if [[ "${presigned_url:-}" ]]; then
     log "Downloading Foundry Virtual Tabletop release."

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -238,6 +238,11 @@ END_OF_LINE
     fi
   fi
 
+  # If another instance is already downloading the requested version, wait
+  while [[ -f "${downloading_filename}" ]]; do
+    sleep 1
+  done
+
   if [[ "${presigned_url:-}" ]]; then
     log "Downloading Foundry Virtual Tabletop release."
     # Temporarily disable errexit for the curl command to capture its exit status


### PR DESCRIPTION
## 🗣 Description ##

If another instance is already downloading our file, we should wait for that download to complete instead of trying to download the same file at the same time (see #1399).

Depends on #1409 and #1410, but apparently stacked PRs are not supported across repositories yet?

Todo: This definitely needs some kind of timeout or other override condition in case a container gets stuck and the download never completes.

## 💭 Motivation and context ##

The most glaring problem should already be fixed by #1410, but it’s probably a good idea not to write to the same file multiple times anyway.

## 🧪 Testing ##

I haven’t tested this yet, just getting the drafts done before I have to head out.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Add a tag or create a release.
