### PR TITLE
Support standard docker individual secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,13 @@ If all goes well you should be prompted with the license agreement, and then
 ## Using secrets ##
 
 This container also supports passing sensitive values via [Docker
-secrets](https://docs.docker.com/engine/swarm/secrets/).  Passing sensitive
+secrets](https://docs.docker.com/compose/how-tos/use-secrets/).  Passing sensitive
 values like your credentials can be more secure using secrets than using
-environment variables.  Your secrets json file can have any name.  This example
+environment variables.
+
+### Config file ###
+
+Your secrets json file can have any name.  This example
 uses `secrets.json`.  Regardless of the name you choose it must be targeted to
 `config.json` within the container as in the example below.  See the
 [secrets](#secrets) section below for a table of all supported secret keys.
@@ -172,6 +176,45 @@ uses `secrets.json`.  Regardless of the name you choose it must be targeted to
           - source: config_json
             target: config.json
     ```
+
+> [!NOTE]
+> A config file variable will override an environment variable.
+
+### Environment variable files ###
+
+The environment variables that are listed in the [secrets](#secrets)
+section below can have `_FILE` appended to them, and then the contents of the
+file can be used instead, this can be more useful when you store them in a
+`.env` file outside of docker:
+
+```yaml
+---
+secrets:
+  foundry_username:
+    environment: "FOUNDRY_USERNAME"
+  foundry_password:
+    environment: "FOUNDRY_PASSWORD"
+
+services:
+  foundry:
+    image: ghcr.io/felddy/foundryvtt:14
+    hostname: my_foundry_host
+    volumes:
+      - type: bind
+        source: <your_data_dir>
+        target: /data
+    environment:
+      - FOUNDRY_USERNAME_FILE="/run/secrets/foundry_username"
+      - FOUNDRY_PASSWORD_FILE="/run/secrets/foundry_password"
+    ports:
+      - target: 30000
+        published: 30000
+        protocol: tcp
+    secrets:
+      - foundry_username
+      - foundry_password
+```
+
 
 ## Updating your container ##
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -144,6 +144,56 @@ if [[ ${image_version%.*} != "${FOUNDRY_VERSION}" ]]; then
   log_warn "The container may not function properly with this version mismatch."
 fi
 
+# Check if running docker secrets
+if [[ "${FOUNDRY_ADMIN_KEY_FILE:-}" ]]; then
+  if [ -f "${FOUNDRY_ADMIN_KEY_FILE}" ]; then
+    log_debug "Loading FOUNDRY_ADMIN_KEY from file"
+    FOUNDRY_ADMIN_KEY="$(<${FOUNDRY_ADMIN_KEY_FILE})"
+  else
+    log_warn "Trying to load FOUNDRY_ADMIN_KEY from file but it does not exist"
+  fi
+fi
+if [[ "${FOUNDRY_LICENSE_KEY_FILE:-}" ]]; then
+  if [ -f "${FOUNDRY_LICENSE_KEY_FILE}" ]; then
+    log_debug "Loading FOUNDRY_LICENSE_KEY from file"
+    FOUNDRY_LICENSE_KEY="$(<${FOUNDRY_LICENSE_KEY_FILE})"
+  else
+    log_warn "Trying to load FOUNDRY_LICENSE_KEY from file but it does not exist"
+  fi
+fi
+if [[ "${FOUNDRY_PASSWORD_FILE:-}" ]]; then
+  if [ -f "${FOUNDRY_PASSWORD_FILE}" ]; then
+    log_debug "Loading FOUNDRY_PASSWORD from file"
+    FOUNDRY_PASSWORD="$(<${FOUNDRY_PASSWORD_FILE})"
+  else
+    log_warn "Trying to load FOUNDRY_PASSWORD from file but it does not exist"
+  fi
+fi
+if [[ "${FOUNDRY_PASSWORD_SALT_FILE:-}" ]]; then
+  if [ -f "${FOUNDRY_PASSWORD_SALT_FILE}" ]; then
+    log_debug "Loading FOUNDRY_PASSWORD_SALT from file"
+    FOUNDRY_PASSWORD_SALT="$(<${FOUNDRY_PASSWORD_SALT_FILE})"
+  else
+    log_warn "Trying to load FOUNDRY_PASSWORD_SALT from file but it does not exist"
+  fi
+fi
+if [[ "${FOUNDRY_SERVICE_KEY_FILE:-}" ]]; then
+  if [ -f "${FOUNDRY_SERVICE_KEY_FILE}" ]; then
+    log_debug "Loading FOUNDRY_SERVICE_KEY from file"
+    FOUNDRY_SERVICE_KEY="$(<${FOUNDRY_SERVICE_KEY_FILE})"
+  else
+    log_warn "Trying to load FOUNDRY_SERVICE_KEY from file but it does not exist"
+  fi
+fi
+if [[ "${FOUNDRY_USERNAME_FILE:-}" ]]; then
+  if [ -f "${FOUNDRY_USERNAME_FILE}" ]; then
+    log_debug "Loading FOUNDRY_USERNAME from file"
+    FOUNDRY_USERNAME="$(<${FOUNDRY_USERNAME_FILE})"
+  else
+    log_warn "Trying to load FOUNDRY_USERNAME from file but it does not exist"
+  fi
+fi
+
 # Check for raft secrets
 if [ -f "${secret_file}" ]; then
   log "Reading configured secrets from: ${secret_file}"


### PR DESCRIPTION
## 🗣 Description ##

This adds standard docker secrets support for individual environment variables, allowing a server admin to pass values individually.

This follows the "standard" of `<normal_name>_FILE` for variables that support being used as secrets, and updates the readme with information on how to use it. The order of variables is alphabetical (as in the secrets file code).

## 💭 Motivation and context ##

This allows me to have my "secrets" in an env file outside my docker, and to allow them to be used directly without having to create a specifically formatted (json) file for them.

I have a server stack that I publish open-source, and individual secrets are a more standard way of doing this - the change was minor (although I added extra lines for debugging / logging).

Copied from the updated readme, note that this uses standard secrets, so it is just as possible to use an file as per the config alternative:

```yaml
---
secrets:
  foundry_username:
    environment: "FOUNDRY_USERNAME"
  foundry_password:
    environment: "FOUNDRY_PASSWORD"

services:
  foundry:
    image: ghcr.io/felddy/foundryvtt:14
    hostname: my_foundry_host
    volumes:
      - type: bind
        source: <your_data_dir>
        target: /data
    environment:
      - FOUNDRY_USERNAME_FILE="/run/secrets/foundry_username"
      - FOUNDRY_PASSWORD_FILE="/run/secrets/foundry_password"
    ports:
      - target: 30000
        published: 30000
        protocol: tcp
    secrets:
      - foundry_username
      - foundry_password
```

## 🧪 Testing ##

This changes the `entrypoint.sh` file only, and does not have any side-effects beyond adding a `_FILE` suffixed alternative to already existing environment variables.

All variables 

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
