### PR TITLE
ci: conditionally upload Docker scan results based on event type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,9 +79,12 @@ jobs:
       dockerfile: ./Dockerfile
       scan-severity: CRITICAL,HIGH
       # GitHub code scanning only accepts SARIF tied to a branch ref or a pull
-      # request, so skip the Security-tab upload on tag pushes (refs/tags/*)
-      # and release events, where codeql-action fails with "GITHUB_REF ... must
-      # be set". The scan still runs; only the upload is skipped on those refs.
+      # request, so upload only for PRs, the merge queue, and branch refs
+      # (refs/heads/*, which also covers scheduled and dispatch runs on a
+      # branch). Skip it on release events and tag refs (refs/tags/*), where
+      # codeql-action has no branch to attach results to and fails with
+      # "GITHUB_REF ... must be set". The scan still runs; only the
+      # Security-tab upload is skipped on those refs.
       upload-scan-results: >-
         ${{ github.event_name == 'pull_request'
           || github.event_name == 'merge_group'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,14 @@ jobs:
       context: .
       dockerfile: ./Dockerfile
       scan-severity: CRITICAL,HIGH
+      # GitHub code scanning only accepts SARIF tied to a branch ref or a pull
+      # request, so skip the Security-tab upload on tag pushes (refs/tags/*)
+      # and release events, where codeql-action fails with "GITHUB_REF ... must
+      # be set". The scan still runs; only the upload is skipped on those refs.
+      upload-scan-results: >-
+        ${{ github.event_name == 'pull_request'
+          || github.event_name == 'merge_group'
+          || startsWith(github.ref, 'refs/heads/') }}
       build-args: |
         CONTAINER_VERSION=${{ needs.config.outputs.container_version }}
         FOUNDRY_VERSION=${{ needs.config.outputs.foundry_version }}


### PR DESCRIPTION
- Add conditional upload-scan-results flag to Docker build step
- Skip Security-tab upload on tag pushes and release events where codeql-action fails
- Allow scan results upload only for pull requests, merge group events, and branch pushes
- Add detailed comments explaining GitHub code scanning SARIF requirements and limitations

]