### PR TITLE
Preserve environment values containing spaces in the launcher carry list

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -89,7 +89,7 @@ done
 log "Starting felddy/foundryvtt container v${image_version}"
 log_debug "CONTAINER_VERBOSE set.  Debug logging enabled."
 log_debug "Running as: $(id)"
-log_debug "Environment:\n$(env | sort | sed -E 's/(.*PASSWORD|KEY.*)=.*/\1=[REDACTED]/g')"
+log_debug "Environment:\n$(env | sort | sed -E 's/([^=]*(PASSWORD|KEY|SECRET|TOKEN|SALT)[^=]*)=.*/\1=[REDACTED]/g')"
 log_debug "Data directory: ${DATA_DIR}"
 
 # Show the mount details for the data directory

--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -77,14 +77,16 @@ fi
 # Space separated list of regex rules which environment variables must meet to
 # be carried over to the new environment, which Node/Foundry will be running in.
 ENV_VAR_PASSLIST_REGEX='^HOME$ ^NODE_.+$ ^TZ$ .+_(PROXY|proxy)$'
-# Build list of environment variables to carry over into a clean environment
-ENV_VAR_CARRY_LIST=''
+# Build list of environment variables to carry over into a clean environment.
+# An array keeps values containing spaces (e.g. NODE_OPTIONS="--a --b") as
+# single NAME=VALUE arguments to env.
+ENV_VAR_CARRY=()
 # shellcheck disable=SC3045
 # busybox read supports the -rd option
 while IFS='=' read -rd '' ENV_VAR_NAME ENV_VAR_VALUE; do
   for VAR_REGEX in $ENV_VAR_PASSLIST_REGEX; do
     if [[ $ENV_VAR_NAME =~ ${VAR_REGEX} ]]; then
-      ENV_VAR_CARRY_LIST="${ENV_VAR_CARRY_LIST} ${ENV_VAR_NAME}=${ENV_VAR_VALUE}"
+      ENV_VAR_CARRY+=("${ENV_VAR_NAME}=${ENV_VAR_VALUE}")
       break
     fi
   done
@@ -92,6 +94,5 @@ done < <(env -0)
 
 # Exec node with clean environment to prevent credential leaks
 log "Starting Foundry Virtual Tabletop."
-# We want ENV_VAR_CARRY_LIST to word split
-# shellcheck disable=SC2086
-exec env -i $ENV_VAR_CARRY_LIST /usr/local/bin/node "$@" || log_error "Exec failed with code $?"
+# ${arr[@]+...} guards the empty-array case under `set -o nounset` on bash <4.4
+exec env -i ${ENV_VAR_CARRY[@]+"${ENV_VAR_CARRY[@]}"} /usr/local/bin/node "$@" || log_error "Exec failed with code $?"


### PR DESCRIPTION
## 🗣 Description

`src/launcher.sh` builds the clean-environment carry list as a
  single string and expands it unquoted into env -i. Any
  passlisted variable whose value contains a space word-splits
  at exec time.

  This PR builds the carry set as a bash array instead, so each
  NAME=VALUE reaches env as a single argument. The
  ${arr[@]+"${arr[@]}"} expansion guards the empty-array case
  under set -o nounset on bash < 4.4. ENV_VAR_PASSLIST_REGEX is
  unchanged.

  A second, related commit widens the CONTAINER_VERBOSE
  env-dump redaction in src/entrypoint.sh: the current pattern
  (.*PASSWORD|KEY.*)=.* only matches the keyword adjacent to =,
  so values like FOUNDRY_PASSWORD_SALT (and any
  *_SECRET/*_TOKEN) print in clear. The pattern now matches
  PASSWORD|KEY|SECRET|TOKEN|SALT anywhere in the variable name.
  The commits are independent and cherry-pickable if you'd
  prefer to take only one.

##  💭 Motivation and context

  With e.g. NODE_OPTIONS='--max-old-space-size=4096 
  --enable-source-maps' (matches the ^NODE_.+$ passlist), env
  receives --enable-source-maps as a standalone argument and
  treats it as the program to execute, failing with env: 
  '--enable-source-maps': No such file or directory. The exec
  never reaches Node and the container crash-loops through the
  backoff handler.

  Resolves #1467

##  🧪 Testing

  - Reproduced the crash-loop against
  ghcr.io/felddy/foundryvtt:release with the spaced
  NODE_OPTIONS above (log output attached to #1467).
  - Verified the array-based carry loop delivers spaced values
  as a single intact variable, and the empty-carry edge case
  under set -o nounset.
  - Redaction pattern verified against FOUNDRY_PASSWORD_SALT,
  NGROK_AUTH_TOKEN, MY_SECRET, plus a non-sensitive HOME
  control (only the control prints its value).
  - The passlist tests in tests/test_launcher.py parse
  ENV_VAR_PASSLIST_REGEX, which is unchanged; shellcheck
  reports no new findings on either file.
  - Ran the repo's pre-commit shellcheck and shfmt hooks
  (same versions/flags) on both changed files: clean. Full
  pytest suite: 36/36 pass on this branch.
  
##  ✅ Pre-approval checklist

  - [x] This PR has an informative and human-readable title.
  - [x] Changes are limited to a single goal - eschew scope 
  creep!
  - [x] I have read the CONTRIBUTING document.
  - [x] All new and existing tests pass.
  - [ ] All relevant type-of-change labels have been added.
