### PR TITLE
feat: add Renovate configuration and workflows

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customDatasources": {
+    "foundryvtt": {
+      "defaultRegistryUrlTemplate": "https://api.github.com/repos/foundryvtt/foundryvtt/milestones?state=closed&per_page=100&sort=due_on&direction=desc",
+      "format": "json",
+      "transformTemplates": [
+        "{ \"releases\": [$[state = \"closed\" and $contains(title, \"Stable\")].{ \"version\": $match(title, /- (\\d+\\.\\d+)$/).groups[0] & \".0\", \"releaseTimestamp\": updated_at, \"changelogUrl\": \"https://foundryvtt.com/releases/\" & $match(title, /- (\\d+\\.\\d+)$/).groups[0] }[version != \".0\"]], \"homepage\": \"https://foundryvtt.com\", \"sourceUrl\": \"https://github.com/foundryvtt/foundryvtt\" }"
+      ]
+    }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "custom.foundryvtt",
+      "depNameTemplate": "foundryvtt",
+      "description": "Track FoundryVTT stable releases via src/version.txt",
+      "managerFilePatterns": [
+        "/^src/version\\.txt$/"
+      ],
+      "matchStrings": [
+        "^(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s*$"
+      ],
+      "versioningTemplate": "semver"
+    }
+  ],
+  "enabledManagers": [
+    "custom.regex"
+  ],
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "commitMessageTopic": "FoundryVTT",
+      "labels": [
+        "bot :robot:",
+        "dependencies :game_die:"
+      ],
+      "matchDatasources": [
+        "custom.foundryvtt"
+      ],
+      "prBodyNotes": [
+        "The `renovate-readme-sync` workflow re-renders `README.md` from `README.md.j2` on this branch automatically."
+      ]
+    }
+  ]
+}

--- a/.github/workflows/renovate-readme-sync.yml
+++ b/.github/workflows/renovate-readme-sync.yml
@@ -1,0 +1,100 @@
+---
+name: Renovate README sync
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - renovate/**
+    paths:
+      - src/version.txt
+
+defaults:
+  run:
+    shell: bash -Eueo pipefail -x {0}
+
+concurrency:
+  # One sync per branch at a time; a rebase by Renovate supersedes any
+  # in-flight run for the same branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  diagnostics:
+    name: Run Diagnostics
+    uses: felddy/reusable-workflows/.github/workflows/diagnostics.yml@76486c28caa391f5f9db4941fc555a20a6e084c8 # tag=v4.2.0
+
+  render:
+    needs:
+      - diagnostics
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # tag=v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            files.pythonhosted.org:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            release-assets.githubusercontent.com:443
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag=v7.0.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # tag=v8.3.2
+      - name: Render README.md from its template
+        run: make README.md
+      - name: Check whether the rendered README differs
+        id: diff
+        run: |
+          if git diff --quiet README.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Generate a GitHub App installation token
+        id: app-token
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # tag=v3.2.0
+        with:
+          client-id: ${{ vars.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Commit the rendered README to the Renovate branch
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ github.ref_name }}
+          EXPECTED_HEAD: ${{ github.sha }}
+        # Override the workflow default shell to drop `-x`: xtrace would
+        # echo the entire base64-encoded README into the log when the
+        # command substitution below is expanded.
+        shell: bash -Eueo pipefail {0}
+        run: |
+          # Commit through the GraphQL API rather than `git push` so the
+          # commit is GitHub-verified (the development ruleset requires
+          # signatures) and is authored by the same App identity Renovate
+          # commits with, which keeps Renovate rebasing the branch instead
+          # of treating it as user-modified.  expectedHeadOid makes the
+          # mutation fail cleanly if Renovate rebased the branch while this
+          # job was running; the superseding push will re-run the sync.
+          gh api graphql \
+            -F "repo=${GITHUB_REPOSITORY}" \
+            -F "branch=${BRANCH}" \
+            -F "expectedHead=${EXPECTED_HEAD}" \
+            -F "readme=$(base64 -w0 README.md)" \
+            -f query='
+              mutation ($repo: String!, $branch: String!, $expectedHead: GitObjectID!, $readme: Base64String!) {
+                createCommitOnBranch(input: {
+                  branch: {repositoryNameWithOwner: $repo, branchName: $branch}
+                  expectedHeadOid: $expectedHead
+                  message: {headline: "Render README.md for the FoundryVTT version bump"}
+                  fileChanges: {additions: [{path: "README.md", contents: $readme}]}
+                }) {
+                  commit { oid }
+                }
+              }'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,81 @@
+---
+name: Renovate
+
+on: # yamllint disable-line rule:truthy
+  schedule:
+    - cron: 38 */6 * * * # four times a day, offset from the build cron
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        default: false
+        description: Log what would happen without creating branches or PRs
+        required: false
+        type: boolean
+      log-level:
+        default: info
+        description: Renovate log level
+        options:
+          - debug
+          - info
+        required: false
+        type: choice
+
+defaults:
+  run:
+    shell: bash -Eueo pipefail -x {0}
+
+concurrency:
+  # Only one Renovate run at a time; a second scheduled run would race the
+  # first on branch creation and rebasing.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  diagnostics:
+    name: Run Diagnostics
+    uses: felddy/reusable-workflows/.github/workflows/diagnostics.yml@76486c28caa391f5f9db4941fc555a20a6e084c8 # tag=v4.2.0
+
+  renovate:
+    needs:
+      - diagnostics
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # tag=v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            ghcr.io:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
+      - name: Generate a GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # tag=v3.2.0
+        with:
+          client-id: ${{ vars.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+      - name: Run Renovate
+        uses: renovatebot/github-action@22e0a16091fc706b04affe6ae53d5e3358ac4023 # tag=v46.1.19
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+        env:
+          LOG_LEVEL: ${{ inputs.log-level || 'info' }}
+          # Only operate on this repository; the repository-level config at
+          # .github/renovate.json controls what gets updated.
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # The config is committed, so skip onboarding PRs.
+          RENOVATE_ONBOARDING: "false"
+          # Commit via the GitHub API as the App instead of `git push`.  This
+          # produces GitHub-verified (signed) commits and makes the commit
+          # author identical to the one used by the renovate-readme-sync
+          # workflow, so Renovate does not treat the rendered README commit
+          # as a user modification and keeps rebasing its branches.
+          RENOVATE_PLATFORM_COMMIT: enabled
+          RENOVATE_DRY_RUN: ${{ inputs.dry-run == true && 'full' || null }}


### PR DESCRIPTION
This pull request introduces Renovate automation to the repository, enabling automatic tracking and updating of FoundryVTT stable releases via `src/version.txt`, and ensuring that the `README.md` stays in sync with the current version. The changes include configuration, workflows, and integration with GitHub App authentication for secure, verified commits.

**Renovate automation and configuration:**

* Added `.github/renovate.json` to configure Renovate, including a custom datasource for FoundryVTT stable releases, a regex-based custom manager for `src/version.txt`, and rules for PR labeling and commit messages.
* Added `.github/workflows/renovate.yml` to run Renovate on a schedule and manually, using a GitHub App token for verified commits and to avoid onboarding PRs.

**README synchronization automation:**

* Added `.github/workflows/renovate-readme-sync.yml` to automatically re-render `README.md` from its template (`README.md.j2`) whenever `src/version.txt` changes on a Renovate branch, and commit the result using the same GitHub App identity as Renovate.# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] All new and existing tests pass.

