### PR TITLE
fix(launcher/entrypoint): env carry array + widen verbose redaction

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -89,7 +89,7 @@ done
 log "Starting felddy/foundryvtt container v${image_version}"
 log_debug "CONTAINER_VERBOSE set.  Debug logging enabled."
 log_debug "Running as: $(id)"
-log_debug "Environment:\n$(env | sort | sed -E 's/(.*PASSWORD|KEY.*)=.*/\1=[REDACTED]/g')"
+log_debug "Environment:\n$(env | sort | sed -E 's/([^=]*(PASSWORD|KEY|SECRET|TOKEN|SALT)[^=]*)=.*/\1=[REDACTED]/g')"
 log_debug "Data directory: ${DATA_DIR}"
 
 # Show the mount details for the data directory

--- a/src/launcher.sh
+++ b/src/launcher.sh
@@ -77,14 +77,16 @@ fi
 # Space separated list of regex rules which environment variables must meet to
 # be carried over to the new environment, which Node/Foundry will be running in.
 ENV_VAR_PASSLIST_REGEX='^HOME$ ^NODE_.+$ ^TZ$ .+_(PROXY|proxy)$'
-# Build list of environment variables to carry over into a clean environment
-ENV_VAR_CARRY_LIST=''
+# Build list of environment variables to carry over into a clean environment.
+# An array keeps values containing spaces (e.g. NODE_OPTIONS="--a --b") as
+# single NAME=VALUE arguments to env.
+ENV_VAR_CARRY=()
 # shellcheck disable=SC3045
 # busybox read supports the -rd option
 while IFS='=' read -rd '' ENV_VAR_NAME ENV_VAR_VALUE; do
   for VAR_REGEX in $ENV_VAR_PASSLIST_REGEX; do
     if [[ $ENV_VAR_NAME =~ ${VAR_REGEX} ]]; then
-      ENV_VAR_CARRY_LIST="${ENV_VAR_CARRY_LIST} ${ENV_VAR_NAME}=${ENV_VAR_VALUE}"
+      ENV_VAR_CARRY+=("${ENV_VAR_NAME}=${ENV_VAR_VALUE}")
       break
     fi
   done
@@ -92,6 +94,5 @@ done < <(env -0)
 
 # Exec node with clean environment to prevent credential leaks
 log "Starting Foundry Virtual Tabletop."
-# We want ENV_VAR_CARRY_LIST to word split
-# shellcheck disable=SC2086
-exec env -i $ENV_VAR_CARRY_LIST /usr/local/bin/node "$@" || log_error "Exec failed with code $?"
+# ${arr[@]+...} guards the empty-array case under `set -o nounset` on bash <4.4
+exec env -i ${ENV_VAR_CARRY[@]+"${ENV_VAR_CARRY[@]}"} /usr/local/bin/node "$@" || log_error "Exec failed with code $?"


### PR DESCRIPTION
Two small, independent fixes in the container launch path.

## 1. `launcher.sh` — carry env vars as an array (correctness)

The carry list is expanded unquoted into `env -i`, so any passlisted variable whose value contains a space breaks the exec command line:

```
NODE_OPTIONS="--max-old-space-size=4096 --enable-source-maps"
```

splits into `NODE_OPTIONS=--max-old-space-size=4096` plus a stray `--enable-source-maps`, which `env` treats as the program to run — exec fails and the container crash-loops through backoff instead of starting Foundry.

Build the carry set as a bash array so each `NAME=VALUE` reaches `env` as one argument. The `${arr[@]+...}` expansion guards the empty-array case under `set -o nounset` on bash < 4.4.

Repro:
```
NODE_OPTIONS='--a --b' bash -c '<carry loop>; env -i $LIST env'
# -> env: '--b': No such file or directory
```

## 2. `entrypoint.sh` — widen verbose env-dump redaction (security)

The redaction regex `(.*PASSWORD|KEY.*)=.*` misses variables where the sensitive token is not adjacent to `=`: `FOUNDRY_PASSWORD_SALT`, and any `*_SECRET` / `*_TOKEN` names, are printed in clear in the `CONTAINER_VERBOSE` environment dump. Match the sensitive keyword anywhere in the variable name and add `SECRET` / `TOKEN` / `SALT`.

Both changes are limited to `src/launcher.sh` and `src/entrypoint.sh`; no behavior change outside the described cases.