### PR TITLE
fix: apply Debian security updates in a patched-base stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,41 @@
 ARG CONTAINER_VERSION
 ARG FOUNDRY_RELEASE_URL
 ARG FOUNDRY_VERSION
-ARG NODE_IMAGE_VERSION=24-trixie-slim
+# Base image coordinates.  DEBIAN_SUITE is the single source of truth: it
+# selects the node image variant below and the Debian archives tracked by the
+# archive-state stage.  Global ARG defaults are expanded against previously
+# declared global ARGs, so the declaration order here matters.
+ARG NODE_MAJOR_VERSION=24
+ARG DEBIAN_SUITE=trixie
+ARG NODE_IMAGE_VERSION=${NODE_MAJOR_VERSION}-${DEBIAN_SUITE}-slim
 ARG NPM_VERSION=11.12.1
 
-FROM public.ecr.aws/docker/library/node:${NODE_IMAGE_VERSION} AS base
+# This stage exists solely to track the state of the Debian archives that carry
+# security fixes.  BuildKit revalidates remote ADD sources on every build and
+# derives their cache key from the fetched content, so patched-base below - and
+# everything downstream of it - is invalidated exactly when these archives are
+# republished.  Without this, the RUN in patched-base would be cached
+# indefinitely and would silently stop applying new security updates.
+#
+# The InRelease files are architecture independent (~45 KB each) and are only
+# bind-mounted, so nothing from this stage is committed to any image layer.
+FROM scratch AS archive-state
+ARG DEBIAN_SUITE
+ADD https://deb.debian.org/debian-security/dists/${DEBIAN_SUITE}-security/InRelease /security
+ADD https://deb.debian.org/debian/dists/${DEBIAN_SUITE}-updates/InRelease /updates
+
+# Apply Debian security updates for every downstream stage.  The upstream node
+# image's Debian rootfs is built from the main archive only, so fixes published
+# to <suite>-security are absent from it until a Debian point release folds
+# them into main.  This affects the shipped image and the stages that handle
+# credentials and untrusted downloads alike.
+FROM public.ecr.aws/docker/library/node:${NODE_IMAGE_VERSION} AS patched-base
+RUN --mount=type=bind,from=archive-state,target=/run/archive-state \
+  apt-get update \
+  && apt-get upgrade -y --with-new-pkgs \
+  && rm -rf /var/lib/apt/lists/*
+
+FROM patched-base AS base
 ARG NPM_VERSION
 RUN npm install -g npm@${NPM_VERSION}
 


### PR DESCRIPTION
## Summary

Trivy has been failing builds on 9 HIGH findings, all of them CVE-2026-53615 in
the `util-linux` source package, counted once per binary package: `bsdutils`,
`libblkid1`, `liblastlog2-2`, `libmount1`, `libsmartcols1`, `libuuid1`, `login`,
`mount`, `util-linux`. Installed `2.41-5`, fixed in `2.41.5-0+deb13u1`.

## Why newer base images do not fix this

This was the surprising part. The base image is not stale — the build resolves
`node:24-trixie-slim` to the current digest, and that image was built 2026-08-05
on a Debian rootfs snapshotted 2026-08-03.

The problem is which archive Debian's official images are built from:

| | |
|---|---|
| `util-linux` in trixie **main** | `2.41-5` |
| `util-linux` in trixie-**security** | `2.41.5-0+deb13u1`, published 2026-07-31 |
| proposed-updates (`stable-new`, for 13.7) | `2.41.5-0+deb13u1` |

Debian's rootfs images track **main**, not security. The fix will not appear in
main until a point release folds it in. So waiting for a rebuilt `node` image
waits for something that will not arrive. And our `apt-get install` of
`curl`/`file`/`jq`/etc. never upgrades pre-existing base packages, so
`util-linux` stayed frozen at whatever the rootfs shipped.

This is a recurring class of failure, not a one-off: it happens every time
Debian ships a security update ahead of a point release.

## Changes

- **`patched-base`** runs `apt-get upgrade -y --with-new-pkgs`, placed beneath
  `base` so all downstream stages inherit it. `--with-new-pkgs` matters because
  plain `apt-get upgrade` will not install new packages, and would silently hold
  back a future fix that bumps a soname.
- **`archive-state`** is a `scratch` stage that `ADD`s the Debian `InRelease`
  files, bind-mounted into the patch RUN.
- **`DEBIAN_SUITE`** is now the single source of truth, composed into
  `NODE_IMAGE_VERSION` and the archive URLs.

Patching applies to the build stages too, not just the shipped image. That
matters most for `optional-release-stage`, which handles the Foundry credentials
and unpacks a downloaded archive.

## Why `archive-state` exists

BuildKit caches `RUN` layers by command string plus parent digest, with no
awareness that apt output is time dependent. The
[docs](https://docs.docker.com/build/cache/invalidation/) are explicit: rebuilding
a week later "will still get you the same packages as before."

`patched-base` sits directly on the `FROM` with no preceding `COPY`, so its cache
key would be extremely stable. Without a counter-measure the upgrade would run
once, get cached, and silently stop applying new security updates — reintroducing
exactly the staleness this PR is fixing.

`ADD` from a URL is the fix. `httpSourceHandler.CacheKey()` in BuildKit issues a
conditional request every build and derives the key from the **fetched content**,
not the URL string. Bind-mounting those files into the RUN ties invalidation to
actual archive state. Bind mounts participate in the cache checksum but are not
committed, so this costs nothing in the final image.

This keeps the intent in the Dockerfile rather than depending on a
`no-cache-filters` flag or a cache-busting build arg, and it fails loudly: if
`DEBIAN_SUITE` ever drifts out of sync with the base image, the `ADD` 404s and
the build breaks instead of quietly skipping patches.

## Testing

Verified locally on `linux/arm64`:

- `--call=outline` confirms the composed ARG resolves `NODE_IMAGE_VERSION` to
  `24-trixie-slim`.
- All 9 packages upgrade to `2.41.5-0+deb13u1`.
- `/run/` contains no `archive-state` directory; the mount leaves nothing behind.
- Trivy under CI's exact gate settings (`--ignore-unfixed`, CRITICAL+HIGH,
  `os,library`) reports **0 findings for Debian packages, down from 9**.
- Cache behaves both ways: unchanged archive content leaves the RUN `CACHED`,
  while changed content re-executes it against an identical base image digest.

## Size cost

An 11 MB layer on arm64, roughly 6.5 MiB on amd64. Layers are additive, so we pay
the full size of the replacement packages rather than the delta — the originals
remain in the base image layers. Since the layer is stable across Foundry
releases, users download it once per patch cycle rather than on every release.

## Known issues

- **Not fully green on its own.** The scan still shows 1 HIGH,
  `undici 7.28.0 -> 7.29.0` (CVE-2026-13697), which exists on `develop` and is
  unrelated to this change. Dependabot PR #1496 bumps it. This branch needs that
  to land, or a rebase onto it, to go fully green.
- **Dependabot cannot parse a composed base image tag.** Making
  `NODE_IMAGE_VERSION` a composition of ARGs closes the door on automated base
  image bumps. In practice nothing regresses: all previous `NODE_IMAGE_VERSION`
  changes were manual commits, and Renovate here is scoped to
  `enabledManagers: ["custom.regex"]` for `src/version.txt` only.
- **Only arm64 was built locally.** amd64, ppc64le, and s390x are unverified
  outside CI. Using the architecture-independent `InRelease` files rather than
  per-arch `Packages` avoids the `ppc64el`/`ppc64le` naming mismatch that would
  otherwise break ppc64le.
- **Reproducibility.** The patch layer's contents now depend on archive state at
  build time. The final stage already ran `apt-get install`, so this is not a new
  class of nondeterminism, but it is more of it.
